### PR TITLE
Potential fix for code scanning alert no. 1: Accepting unknown SSH host keys when using Paramiko

### DIFF
--- a/diagnose_and_fix_css.py
+++ b/diagnose_and_fix_css.py
@@ -35,7 +35,7 @@ try:
     # Connect to server
     print("Connecting to server...")
     ssh = paramiko.SSHClient()
-    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.set_missing_host_key_policy(paramiko.RejectPolicy())
     ssh.connect(hostname, username=username, password=password)
     print("✓ Connected successfully")
 


### PR DESCRIPTION
Potential fix for [https://github.com/Trujillofa/depotru_database/security/code-scanning/1](https://github.com/Trujillofa/depotru_database/security/code-scanning/1)

In general, to fix this issue you must not automatically accept unknown host keys. Instead, you should either (a) rely on Paramiko’s default `RejectPolicy`, which raises an exception when a host key is unknown, or (b) explicitly configure a known_hosts file and load host keys before connecting. Both approaches preserve SSH’s host verification and prevent silent acceptance of potentially malicious hosts.

The minimal, behavior-preserving fix here is to stop using `AutoAddPolicy` and use a rejecting policy instead. Since the script does not show any custom host-key logic elsewhere, the best change is to replace `ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())` with `ssh.set_missing_host_key_policy(paramiko.RejectPolicy())`. This maintains the explicitness of the policy setting while making it secure: the connection will now fail with an exception if the server’s host key is not already trusted. Because `paramiko.RejectPolicy` is available from the existing `paramiko` import, no additional imports are necessary, and no other functionality in the script needs to change.

Concretely, in `diagnose_and_fix_css.py`, around line 38 where the SSH client is configured, change the call to `set_missing_host_key_policy` so that it passes `paramiko.RejectPolicy()` instead of `paramiko.AutoAddPolicy()`. All other code can remain as-is; any connection failures due to unknown host keys will be handled by the existing `try`/`except` block around the connection and command execution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
