### PR TITLE
Potential fix for code scanning alert no. 27: Unused import

### DIFF
--- a/src/vanna_chat.py
+++ b/src/vanna_chat.py
@@ -27,11 +27,11 @@ Then open http://localhost:8084 in your browser and start asking questions!
 """
 
 import os
-from typing import Optional
 
 # ============================================================================
 # CONFIGURATION - CHOOSE YOUR SETUP
 # ============================================================================
+
 
 # Option 1: Use OpenAI (Recommended for best results)
 USE_OPENAI = True


### PR DESCRIPTION
Potential fix for [https://github.com/Trujillofa/depotru_database/security/code-scanning/27](https://github.com/Trujillofa/depotru_database/security/code-scanning/27)

To fix an unused-import issue, you remove the import statement for any symbol that is not referenced anywhere in the file. This reduces clutter and avoids misleading readers into thinking that the imported type or module is relevant.

In this specific case, the best fix is to delete the line `from typing import Optional` from `src/vanna_chat.py`. No other code changes are needed, since we are not introducing new functionality or altering existing behavior; we are only cleaning up an unused import. The relevant change is around line 30 of `src/vanna_chat.py`, where the imports are declared.

No new methods, imports, or definitions are required to implement this change; it is purely a deletion of the unused import line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
