### PR TITLE
ci: make dependency-review and claude-code-review non-blocking

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,6 +19,9 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    # Non-blocking: depends on CLAUDE_CODE_OAUTH_TOKEN secret, which
+    # may be expired or unset. Keep the review signal without failing merges.
+    continue-on-error: true
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    # Non-blocking: requires GitHub Advanced Security, which is not
+    # enabled on this repo. Keep the signal without failing merges.
+    continue-on-error: true
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds `continue-on-error: true` to both the `dependency-review` job and the `claude-code-review` job.
- Preserves review signal in the Checks tab without blocking merges on infra outside the PR author's control:
  - `dependency-review` needs GitHub Advanced Security, which isn't enabled on this repo.
  - `claude-code-review` depends on `CLAUDE_CODE_OAUTH_TOKEN`, which may be expired/unset (needs separate rotation).

## Test plan
- [ ] Verify both jobs run and report status, but don't fail the PR as a whole
- [ ] Rotate `CLAUDE_CODE_OAUTH_TOKEN` so Claude review runs succeed going forward (repo admin action, separate from this PR)
- [ ] Consider enabling GHAS or removing `dependency-review` entirely in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)