### PR TITLE
feat(wms): website J3 warehouse allowlist + stock CLI (#182)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,9 @@ jobs:
       - name: Install linting tools
         run: |
           python -m pip install --upgrade pip
-          pip install black==23.12.1 isort flake8 flake8-pyproject
+          # Pin isort to pre-commit rev (5.13.2). Unpinned isort 8.x reformats
+          # imports incompatibly and fails Lint on otherwise-clean trees.
+          pip install black==23.12.1 isort==5.13.2 flake8 flake8-pyproject
 
       - name: Check code formatting with black
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Website J3 warehouse allowlist** (depositotrujillo.co#182):
+  - SSOT: `website_warehouse_policy` denylist CEN/EXH/EXD/BDT/MDL/TRA
+  - SQL: website vs excluded stock from `InvDetalleExistencias`
+  - CLI: `depotru-website-stock` (impact report, Magento compare, gated MSI write)
+  - Magento client: optional `post_source_items`
+  - Docs: `docs/reference/website-warehouse-allowlist.md`
 - **Platform Phase 0 skeleton** for multi-module scale (Magento assistant, CRM, WMS, catalog):
   - `depotru_kernel` — document exclusions, COP formatting, unified attribution wrapper, audience/scopes
   - `depotru_tools` — capability registry + builtins (`platform.health`, `info.branches`, `attribution.resolve_seller`, `catalog.related_for_sku`, `inventory.sellable_qty`)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -65,9 +65,13 @@ Platform adapters bridge them; Magento never free-form queries MSSQL.
 
 ## Non-goals (near term)
 
-- Replace b2c.smart-business inventory writer
+- Full replacement of b2c.smart-business inventory writer (still primary feed)
 - Full CRM SPA before APIs
 - Public exposure of cost / cartera
+
+**Related (shipped tooling, not a full rewrite):** website J3 warehouse allowlist +
+`depotru-website-stock` CLI measure/optional MSI patch — see
+`docs/reference/website-warehouse-allowlist.md` and depositotrujillo.co#182.
 
 ---
 

--- a/docs/reference/website-warehouse-allowlist.md
+++ b/docs/reference/website-warehouse-allowlist.md
@@ -1,0 +1,61 @@
+# Website stock — J3 warehouse allowlist
+
+**Issue:** [depositotrujillo.co#182](https://github.com/Trujillofa/depositotrujillo.co/issues/182)
+**Code SSOT:** `business_analyzer.core.website_warehouse_policy`
+**CLI:** `depotru-website-stock`
+
+## Problem
+
+b2c.smart-business.app aggregates J3 inventory into Magento MSI (`default` + `CENTRO`).
+If **all** J3 almacenes are included, website salable qty can include stock that must not be sold online (garantías, exhibición, ML, etc.).
+
+Magento never stores J3 codes — filtering must happen **before** Magento (B2C config) or via a controlled writer that only posts allowlisted totals.
+
+## Policy (ops 2026-07-14)
+
+### Denylist (exclude)
+
+| Code | Name |
+|------|------|
+| CEN | 005 GARANTIAS |
+| EXH | BOD EXHIBICION ALMACEN |
+| EXD | BOD EXHIBICION DISTRIBUCIONES |
+| BDT | BODEGA AJUSTES TEMPORALES |
+| MDL | MERCADO LIBRE |
+| TRA | MCIA COMITECAFE |
+
+### Allowlist (include)
+
+ALM, SUR, BD6, BOD, DIS, FLO, B.ROT, CON
+
+### Magento dual source
+
+Website channel uses stock **Total Disponible** = `default` + `CENTRO` **intentionally** (promos).
+Do not collapse MSI stock linkage without a new product decision.
+
+## CLI
+
+```bash
+# Impact: how much qty sits on denylisted warehouses
+depotru-website-stock
+
+# Top SKUs with excluded stock (JSON)
+depotru-website-stock --json --top-n 50
+
+# Compare a SKU to Magento MSI (needs MAGENTO_BASE_URL + MAGENTO_ACCESS_TOKEN)
+depotru-website-stock --sku 0020280079 --compare-magento
+
+# Gated write (optional; B2C may overwrite)
+depotru-website-stock --sku 0020280079 --apply --source-code default
+```
+
+## Preferred ops path
+
+1. Apply the same denylist in **b2c.smart-business.app** warehouse selection.
+2. Use this repo’s CLI to **measure** impact and verify SKUs.
+3. Only use `--apply` if intentionally shadowing B2C for listed SKUs.
+
+## Related
+
+- `docs/reference/j3system-sales-warehouse-query.md` — sales warehouse routing
+- Sibling runbook: `depositotrujillo.co/docs/runbooks/b2c-website-warehouse-allowlist.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ vanna-grok = "vanna_grok:main"
 vanna-chat = "vanna_grok:main"
 depotru-db-mcp = "business_analyzer.mcp.database_server:main"
 depotru-enrich-celular = "business_analyzer.analysis.cotizaciones_celular_cli:main"
+depotru-website-stock = "business_analyzer.core.website_stock_cli:main"
 
 [project.urls]
 Homepage = "https://github.com/Trujillofa/depotru_database"

--- a/scripts/agent_router.py
+++ b/scripts/agent_router.py
@@ -12,12 +12,13 @@ Usage:
 """
 
 import argparse
-import yaml
 import sys
-from pathlib import Path
-from typing import Dict, List, Optional
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
 
 
 class TaskType(Enum):

--- a/src/business_analyzer/core/j3system_website_stock.py
+++ b/src/business_analyzer/core/j3system_website_stock.py
@@ -1,0 +1,174 @@
+"""J3System website stock totals using the warehouse allowlist (#182).
+
+Sums ``InvDetalleExistencias.SaldoActual`` per SKU only for almacenes in
+``website_warehouse_allowlist()``. Optionally returns per-warehouse breakdown
+and the qty that would be excluded by the denylist.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence
+
+from business_analyzer.core.database import Database
+from business_analyzer.core.j3system_sales_warehouse import qualified_j3_table
+from business_analyzer.core.website_warehouse_policy import (
+    WEBSITE_WAREHOUSE_DENYLIST,
+    sql_in_list,
+    website_warehouse_allowlist,
+)
+
+
+def build_website_stock_by_sku_sql(
+    *,
+    inventory_year: Optional[int] = None,
+    j3_database: Optional[str] = None,
+    sku_filter: Optional[Sequence[str]] = None,
+    top_n: Optional[int] = None,
+) -> str:
+    """Aggregate allowlisted warehouse balances per article code."""
+    allow = website_warehouse_allowlist()
+    allow_sql = sql_in_list(allow)
+    deny_sql = sql_in_list(sorted(WEBSITE_WAREHOUSE_DENYLIST))
+
+    detalle = qualified_j3_table("InvDetalleExistencias", j3_database)
+    existencias = qualified_j3_table("InvExistencias", j3_database)
+    articulos = qualified_j3_table("AdmArticulos", j3_database)
+    almacen = qualified_j3_table("AdmAlmacen", j3_database)
+
+    year_filter = (
+        f"d.Ano = {int(inventory_year)}"
+        if inventory_year is not None
+        else f"d.Ano = (SELECT MAX(Ano) FROM {detalle})"
+    )
+
+    sku_clause = ""
+    if sku_filter:
+        sku_sql = sql_in_list(sku_filter, max_len=40)
+        sku_clause = f"AND a.ArticulosCodigo IN ({sku_sql})"
+
+    top = f"TOP {int(top_n)} " if top_n is not None and int(top_n) > 0 else ""
+
+    return f"""
+SELECT {top}
+    a.ArticulosCodigo AS sku,
+    MAX(a.ArticulosNombre) AS name,
+    CAST(SUM(CASE WHEN al.AlmacenCodigo IN ({allow_sql})
+        THEN CAST(d.SaldoActual AS DECIMAL(18, 4)) ELSE 0 END) AS DECIMAL(18, 4))
+        AS website_qty,
+    CAST(SUM(CASE WHEN al.AlmacenCodigo IN ({deny_sql})
+        THEN CAST(d.SaldoActual AS DECIMAL(18, 4)) ELSE 0 END) AS DECIMAL(18, 4))
+        AS excluded_qty,
+    CAST(SUM(CAST(d.SaldoActual AS DECIMAL(18, 4))) AS DECIMAL(18, 4)) AS all_warehouses_qty,
+    COUNT(DISTINCT CASE WHEN al.AlmacenCodigo IN ({allow_sql})
+        AND CAST(d.SaldoActual AS DECIMAL(18, 4)) > 0
+        THEN al.AlmacenCodigo END) AS allowlist_warehouses_with_qty
+FROM {detalle} d
+JOIN {existencias} e ON e.ExistenciasID = d.ExistenciasID
+JOIN {articulos} a ON a.ArticulosID = e.ArticulosID
+JOIN {almacen} al ON al.AlmacenID = d.AlmacenID
+WHERE {year_filter}
+  AND CAST(d.SaldoActual AS DECIMAL(18, 4)) >= 0
+  AND al.AlmacenCodigo IS NOT NULL
+  AND LTRIM(RTRIM(al.AlmacenCodigo)) <> ''
+  {sku_clause}
+GROUP BY a.ArticulosCodigo
+HAVING SUM(CASE WHEN al.AlmacenCodigo IN ({allow_sql})
+    THEN CAST(d.SaldoActual AS DECIMAL(18, 4)) ELSE 0 END) > 0
+    OR SUM(CASE WHEN al.AlmacenCodigo IN ({deny_sql})
+    THEN CAST(d.SaldoActual AS DECIMAL(18, 4)) ELSE 0 END) > 0
+ORDER BY excluded_qty DESC, website_qty DESC
+""".strip()
+
+
+def build_website_stock_impact_summary_sql(
+    *,
+    inventory_year: Optional[int] = None,
+    j3_database: Optional[str] = None,
+) -> str:
+    """One-row summary: how much stock sits only on denylisted warehouses."""
+    allow = website_warehouse_allowlist()
+    allow_sql = sql_in_list(allow)
+    deny_sql = sql_in_list(sorted(WEBSITE_WAREHOUSE_DENYLIST))
+
+    detalle = qualified_j3_table("InvDetalleExistencias", j3_database)
+    existencias = qualified_j3_table("InvExistencias", j3_database)
+    articulos = qualified_j3_table("AdmArticulos", j3_database)
+    almacen = qualified_j3_table("AdmAlmacen", j3_database)
+
+    year_filter = (
+        f"d.Ano = {int(inventory_year)}"
+        if inventory_year is not None
+        else f"d.Ano = (SELECT MAX(Ano) FROM {detalle})"
+    )
+
+    return f"""
+SELECT
+    CAST(SUM(CASE WHEN al.AlmacenCodigo IN ({allow_sql})
+        THEN CAST(d.SaldoActual AS DECIMAL(18, 4)) ELSE 0 END) AS DECIMAL(18, 4))
+        AS website_qty_sum,
+    CAST(SUM(CASE WHEN al.AlmacenCodigo IN ({deny_sql})
+        THEN CAST(d.SaldoActual AS DECIMAL(18, 4)) ELSE 0 END) AS DECIMAL(18, 4))
+        AS excluded_qty_sum,
+    CAST(SUM(CAST(d.SaldoActual AS DECIMAL(18, 4))) AS DECIMAL(18, 4)) AS all_warehouses_qty_sum,
+    COUNT(DISTINCT a.ArticulosCodigo) AS sku_rows_touched
+FROM {detalle} d
+JOIN {existencias} e ON e.ExistenciasID = d.ExistenciasID
+JOIN {articulos} a ON a.ArticulosID = e.ArticulosID
+JOIN {almacen} al ON al.AlmacenID = d.AlmacenID
+WHERE {year_filter}
+  AND CAST(d.SaldoActual AS DECIMAL(18, 4)) > 0
+  AND al.AlmacenCodigo IS NOT NULL
+  AND LTRIM(RTRIM(al.AlmacenCodigo)) <> ''
+""".strip()
+
+
+class WebsiteStockRunner:
+    """Execute website stock queries against J3System."""
+
+    def __init__(self, db: Optional[Database] = None) -> None:
+        self.db = db or Database()
+
+    def _execute(self, sql: str) -> List[Dict[str, Any]]:
+        self.db.connect()
+        rows = self.db.execute_query(sql)
+        if not isinstance(rows, list):
+            return []
+        return [dict(r) for r in rows]
+
+    def impact_summary(self, *, inventory_year: Optional[int] = None) -> Dict[str, Any]:
+        sql = build_website_stock_impact_summary_sql(inventory_year=inventory_year)
+        rows = self._execute(sql)
+        if not rows:
+            return {}
+        return dict(rows[0])
+
+    def stock_by_sku(
+        self,
+        *,
+        inventory_year: Optional[int] = None,
+        skus: Optional[Sequence[str]] = None,
+        top_n: int = 100,
+    ) -> List[Dict[str, Any]]:
+        sql = build_website_stock_by_sku_sql(
+            inventory_year=inventory_year,
+            sku_filter=skus,
+            top_n=None if skus else top_n,
+        )
+        return self._execute(sql)
+
+    def skus_with_excluded_stock(
+        self,
+        *,
+        inventory_year: Optional[int] = None,
+        top_n: int = 50,
+        min_excluded: float = 1.0,
+    ) -> List[Dict[str, Any]]:
+        """SKUs where denylist warehouses hold qty (website would drop if filtered)."""
+        rows = self.stock_by_sku(
+            inventory_year=inventory_year, top_n=max(top_n * 5, 200)
+        )
+        filtered = [
+            r for r in rows if float(r.get("excluded_qty") or 0) >= min_excluded
+        ]
+        filtered.sort(key=lambda r: float(r.get("excluded_qty") or 0), reverse=True)
+        return filtered[:top_n]

--- a/src/business_analyzer/core/website_stock_cli.py
+++ b/src/business_analyzer/core/website_stock_cli.py
@@ -1,0 +1,247 @@
+"""CLI: website stock from J3 allowlist vs all warehouses (issue #182).
+
+Dry-run by default. Optional Magento compare when MAGENTO_* env is set.
+Optional Magento MSI write with --apply (gated; fights b2c.smart-business if
+that feed is still active — prefer configuring B2C denylist first).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from business_analyzer.core.database import Database
+from business_analyzer.core.j3system_website_stock import WebsiteStockRunner
+from business_analyzer.core.website_warehouse_policy import (
+    MAGENTO_WEBSITE_MSI_SOURCES,
+    policy_summary,
+)
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=(
+            "Website stock allowlist (J3): impact of excluding garantías, "
+            "exhibición, ajustes temporales, MDL, COMITECAFE"
+        )
+    )
+    p.add_argument(
+        "--top-n",
+        type=int,
+        default=30,
+        help="Top SKUs with excluded stock to list (default 30)",
+    )
+    p.add_argument(
+        "--sku",
+        action="append",
+        default=[],
+        help="Limit to SKU (repeatable)",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Print JSON report",
+    )
+    p.add_argument(
+        "--compare-magento",
+        action="store_true",
+        help="Compare sample SKUs to Magento MSI (needs MAGENTO_BASE_URL + token)",
+    )
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "Write website_qty to Magento MSI source-items for --sku list "
+            "(requires --source-code; dangerous if B2C still overwrites)"
+        ),
+    )
+    p.add_argument(
+        "--source-code",
+        default="default",
+        choices=list(MAGENTO_WEBSITE_MSI_SOURCES),
+        help="MSI source to update when using --apply (default: default)",
+    )
+    p.add_argument(
+        "--output",
+        default="",
+        help="Optional path to write markdown/JSON report",
+    )
+    return p.parse_args(argv)
+
+
+def _magento_compare(skus: List[str]) -> List[Dict[str, Any]]:
+    from depotru_integrations.magento.client import MagentoConfig, MagentoRestClient
+
+    config = MagentoConfig.from_env()
+    if not config:
+        return [
+            {
+                "status": "skipped",
+                "reason": "MAGENTO_BASE_URL / MAGENTO_ACCESS_TOKEN not set",
+            }
+        ]
+    client = MagentoRestClient(config)
+    out: List[Dict[str, Any]] = []
+    for sku in skus:
+        try:
+            payload = client.sellable_qty(sku)
+            out.append(
+                {
+                    "sku": sku,
+                    "magento_raw_qty": payload.get("raw_qty"),
+                    "magento_sellable_qty": payload.get("sellable_qty"),
+                    "magento_sources": payload.get("sources"),
+                    "status": "ok",
+                }
+            )
+        except Exception as exc:  # noqa: BLE001 — surface per-SKU errors
+            out.append({"sku": sku, "status": "error", "error": str(exc)})
+    return out
+
+
+def _magento_apply(
+    rows: List[Dict[str, Any]],
+    *,
+    source_code: str,
+) -> List[Dict[str, Any]]:
+    from depotru_integrations.magento.client import MagentoConfig, MagentoRestClient
+
+    config = MagentoConfig.from_env()
+    if not config:
+        raise RuntimeError("Magento not configured (MAGENTO_BASE_URL + token)")
+    client = MagentoRestClient(config)
+    items = []
+    for row in rows:
+        sku = str(row.get("sku") or "")
+        qty = float(row.get("website_qty") or 0)
+        if not sku:
+            continue
+        items.append(
+            {
+                "sku": sku,
+                "source_code": source_code,
+                "quantity": qty,
+                "status": 1 if qty > 0 else 0,
+            }
+        )
+    if not items:
+        return []
+    result = client.post_source_items(items)
+    return [{"posted": len(items), "result": result}]
+
+
+def render_markdown(report: Dict[str, Any]) -> str:
+    pol = report.get("policy") or {}
+    summary = report.get("impact_summary") or {}
+    lines = [
+        "# Website stock — J3 warehouse allowlist",
+        "",
+        f"- **Generated:** {report.get('generated_at')}",
+        f"- **Issue:** {pol.get('issue')}",
+        "",
+        "## Policy",
+        "",
+        f"- **Denylist:** {', '.join(pol.get('denylist') or [])}",
+        f"- **Allowlist:** {', '.join(pol.get('allowlist') or [])}",
+        f"- **Magento MSI:** {', '.join(pol.get('magento_msi_sources') or [])}",
+        f"- **Note:** {pol.get('magento_dual_source_note')}",
+        "",
+        "## J3 impact summary",
+        "",
+        f"- **Website qty (allowlist sum):** {summary.get('website_qty_sum')}",
+        f"- **Excluded qty (denylist sum):** {summary.get('excluded_qty_sum')}",
+        f"- **All warehouses qty:** {summary.get('all_warehouses_qty_sum')}",
+        f"- **SKUs touched:** {summary.get('sku_rows_touched')}",
+        "",
+        "## Top SKUs with stock on denylisted warehouses",
+        "",
+        "| SKU | Name | Website qty | Excluded qty | All qty |",
+        "|-----|------|------------:|-------------:|--------:|",
+    ]
+    for row in report.get("excluded_skus") or []:
+        name = str(row.get("name") or "")[:40]
+        lines.append(
+            f"| {row.get('sku')} | {name} | "
+            f"{float(row.get('website_qty') or 0):.0f} | "
+            f"{float(row.get('excluded_qty') or 0):.0f} | "
+            f"{float(row.get('all_warehouses_qty') or 0):.0f} |"
+        )
+    if report.get("magento_compare"):
+        lines.extend(["", "## Magento compare", ""])
+        for row in report["magento_compare"]:
+            lines.append(f"- `{row}`")
+    lines.extend(
+        [
+            "",
+            "## Next steps",
+            "",
+            "1. Prefer configuring the same denylist in **b2c.smart-business.app** "
+            "so the live feed stops aggregating excluded almacenes.",
+            "2. Use this CLI to measure impact and spot-check SKUs.",
+            "3. Only use `--apply` if intentionally replacing B2C for listed SKUs "
+            "(B2C may overwrite during business hours).",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    if args.apply and not args.sku:
+        print("ERROR: --apply requires at least one --sku", file=sys.stderr)
+        return 2
+
+    runner = WebsiteStockRunner(Database())
+    report: Dict[str, Any] = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "policy": policy_summary(),
+        "impact_summary": runner.impact_summary(),
+        "excluded_skus": (
+            runner.stock_by_sku(skus=args.sku)
+            if args.sku
+            else runner.skus_with_excluded_stock(top_n=args.top_n)
+        ),
+        "mode": "apply" if args.apply else "dry-run",
+    }
+
+    if args.compare_magento:
+        sample = [
+            str(r.get("sku")) for r in report["excluded_skus"][:15] if r.get("sku")
+        ]
+        if args.sku:
+            sample = list(args.sku)
+        report["magento_compare"] = _magento_compare(sample)
+
+    if args.apply:
+        print(
+            "WARNING: Writing Magento MSI. B2C may overwrite during business hours.",
+            file=sys.stderr,
+        )
+        report["magento_apply"] = _magento_apply(
+            report["excluded_skus"],
+            source_code=args.source_code,
+        )
+
+    if args.json:
+        text = json.dumps(report, indent=2, default=str, ensure_ascii=False)
+    else:
+        text = render_markdown(report)
+
+    print(text)
+    if args.output:
+        path = Path(args.output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            text + ("\n" if not text.endswith("\n") else ""), encoding="utf-8"
+        )
+        print(f"Wrote {path}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/business_analyzer/core/website_warehouse_policy.py
+++ b/src/business_analyzer/core/website_warehouse_policy.py
@@ -1,0 +1,109 @@
+"""Website-facing J3 warehouse allowlist / denylist (issue #182).
+
+Magento only stores MSI sources ``default`` and ``CENTRO``; J3 warehouse codes
+never appear on Magento rows. b2c.smart-business.app aggregates ERP stock
+before POST /V1/inventory/source-items.
+
+This module is the **SSOT** for which J3 ``AlmacenCodigo`` values may count
+toward website sellable stock. Magento dual-source sum (default+CENTRO) is
+intentional for promos — see sibling repo issue Trujillofa/depositotrujillo.co#182.
+"""
+
+from __future__ import annotations
+
+from typing import FrozenSet, Iterable, Tuple
+
+# Full known set (keep in sync with j3system_sales_warehouse.WAREHOUSE_CODES).
+ALL_J3_WAREHOUSE_CODES: Tuple[str, ...] = (
+    "ALM",
+    "SUR",
+    "BD6",
+    "DIS",
+    "BOD",
+    "BDT",
+    "FLO",
+    "CEN",
+    "MDL",
+    "EXH",
+    "TRA",
+    "CON",
+    "B.ROT",
+    "EXD",
+)
+
+# Exclude from website / B2C aggregation (ops decision 2026-07-14).
+WEBSITE_WAREHOUSE_DENYLIST: FrozenSet[str] = frozenset(
+    {
+        "CEN",  # 005 GARANTIAS
+        "EXH",  # BOD EXHIBICION ALMACEN
+        "EXD",  # BOD EXHIBICION DISTRIBUCIONES
+        "BDT",  # BODEGA AJUSTES TEMPORALES
+        "MDL",  # MERCADO LIBRE
+        "TRA",  # MCIA COMITECAFE
+    }
+)
+
+WEBSITE_WAREHOUSE_DENYLIST_LABELS = {
+    "CEN": "005 GARANTIAS",
+    "EXH": "BOD EXHIBICION ALMACEN",
+    "EXD": "BOD EXHIBICION DISTRIBUCIONES",
+    "BDT": "BODEGA AJUSTES TEMPORALES",
+    "MDL": "MERCADO LIBRE",
+    "TRA": "MCIA COMITECAFE",
+}
+
+# Magento MSI sources that feed website stock "Total Disponible" (stock_id=3).
+# Dual sum is intentional for website promos — do not collapse without a new decision.
+MAGENTO_WEBSITE_MSI_SOURCES: Tuple[str, ...] = ("default", "CENTRO")
+
+
+def website_warehouse_allowlist(
+    all_codes: Iterable[str] | None = None,
+) -> Tuple[str, ...]:
+    """Return sorted allowlist = all known codes minus denylist."""
+    codes = tuple(all_codes) if all_codes is not None else ALL_J3_WAREHOUSE_CODES
+    allowed = [c for c in codes if c not in WEBSITE_WAREHOUSE_DENYLIST]
+    return tuple(sorted(allowed, key=lambda x: (x.replace(".", ""), x)))
+
+
+def is_website_warehouse(code: str) -> bool:
+    """True if ``code`` is allowed for website stock aggregation."""
+    raw = (code or "").strip()
+    if not raw:
+        return False
+    # Match denylist case-insensitively; preserve known codes like B.ROT
+    denied = {d.upper() for d in WEBSITE_WAREHOUSE_DENYLIST}
+    return raw.upper() not in denied
+
+
+def sql_in_list(codes: Iterable[str], *, max_len: int = 10) -> str:
+    """Build a safe SQL IN-list of short codes (warehouse / SKU codes)."""
+    parts = []
+    for raw in codes:
+        code = str(raw).strip()
+        if not code or len(code) > max_len:
+            raise ValueError(f"Invalid code for SQL IN-list: {raw!r}")
+        # Allow letters, digits, dot, underscore, hyphen
+        if not all(ch.isalnum() or ch in "._-" for ch in code):
+            raise ValueError(f"Invalid code chars: {raw!r}")
+        safe = code.replace("'", "''")
+        parts.append(f"'{safe}'")
+    if not parts:
+        raise ValueError("Code list is empty")
+    return ", ".join(parts)
+
+
+def policy_summary() -> dict:
+    """JSON-serializable policy snapshot for CLIs and reports."""
+    allow = website_warehouse_allowlist()
+    return {
+        "denylist": sorted(WEBSITE_WAREHOUSE_DENYLIST),
+        "denylist_labels": dict(WEBSITE_WAREHOUSE_DENYLIST_LABELS),
+        "allowlist": list(allow),
+        "magento_msi_sources": list(MAGENTO_WEBSITE_MSI_SOURCES),
+        "magento_dual_source_note": (
+            "Website sales channel uses stock Total Disponible = "
+            "default + CENTRO (intentional for promos)."
+        ),
+        "issue": "Trujillofa/depositotrujillo.co#182",
+    }

--- a/src/business_analyzer_combined.py
+++ b/src/business_analyzer_combined.py
@@ -56,9 +56,7 @@ from .analytics.trend_metrics import analyze_trends as analyze_trends_core
 from .config import Config, CustomerSegmentation, InventoryConfig, ProfitabilityConfig
 from .contracts.row_contracts import extract_row_value
 from .data_access import fetch_banco_datos, resolve_connection_details
-from .reporting import (
-    MATPLOTLIB_AVAILABLE,
-)
+from .reporting import MATPLOTLIB_AVAILABLE
 from .reporting import (
     generate_visualization_report as generate_visualization_report_core,
 )

--- a/src/depotru_integrations/magento/client.py
+++ b/src/depotru_integrations/magento/client.py
@@ -1,6 +1,9 @@
 """Thin Magento REST client for platform tools.
 
-Does not replace b2c.smart-business.app inventory writers. Read-only by default.
+Default path is read-only (sellable qty, product search). Optional
+``post_source_items`` supports gated MSI writes for website stock tooling
+(issue #182). Prefer configuring b2c.smart-business warehouse denylist first —
+that feed may overwrite Magento during business hours.
 """
 
 from __future__ import annotations
@@ -202,3 +205,14 @@ class MagentoRestClient:
             "sources": sources,
             "status": "ok",
         }
+
+    def post_source_items(self, items: List[Dict[str, Any]]) -> Any:
+        """POST /V1/inventory/source-items (MSI write).
+
+        Each item: sku, source_code, quantity, status (1 in-stock / 0 OOS).
+        Requires an integration token with inventory write ACL.
+        """
+        if not items:
+            return {"message": "empty"}
+        payload = {"sourceItems": items}
+        return self._request("POST", "/rest/V1/inventory/source-items", body=payload)

--- a/src/modules/wms/__init__.py
+++ b/src/modules/wms/__init__.py
@@ -1,6 +1,23 @@
 """WMS / WSM module — ops stock, coverage, OTIF (distinct from Magento MSI).
 
 Phase 0 scaffold. J3 InvDetalleExistencias + KPI Q13/Q14 power this module.
+
+Website stock allowlist (issue #182): see
+``business_analyzer.core.website_warehouse_policy`` and CLI ``depotru-website-stock``.
 """
 
 MODULE_NAME = "wms"
+
+# Re-export policy helpers for platform tools
+from business_analyzer.core.website_warehouse_policy import (  # noqa: E402
+    WEBSITE_WAREHOUSE_DENYLIST,
+    policy_summary,
+    website_warehouse_allowlist,
+)
+
+__all__ = [
+    "MODULE_NAME",
+    "WEBSITE_WAREHOUSE_DENYLIST",
+    "policy_summary",
+    "website_warehouse_allowlist",
+]

--- a/tests/analysis/test_website_warehouse_policy.py
+++ b/tests/analysis/test_website_warehouse_policy.py
@@ -1,0 +1,78 @@
+"""Unit tests for website warehouse allowlist (#182)."""
+
+import pytest
+
+from business_analyzer.core.j3system_website_stock import (
+    build_website_stock_by_sku_sql,
+    build_website_stock_impact_summary_sql,
+)
+from business_analyzer.core.website_warehouse_policy import (
+    ALL_J3_WAREHOUSE_CODES,
+    WEBSITE_WAREHOUSE_DENYLIST,
+    is_website_warehouse,
+    policy_summary,
+    sql_in_list,
+    website_warehouse_allowlist,
+)
+
+
+@pytest.mark.unit
+def test_denylist_contains_ops_codes():
+    assert WEBSITE_WAREHOUSE_DENYLIST == frozenset(
+        {"CEN", "EXH", "EXD", "BDT", "MDL", "TRA"}
+    )
+
+
+@pytest.mark.unit
+def test_allowlist_excludes_denylist():
+    allow = website_warehouse_allowlist()
+    for code in WEBSITE_WAREHOUSE_DENYLIST:
+        assert code not in allow
+    assert "ALM" in allow
+    assert "SUR" in allow
+    assert "B.ROT" in allow
+    assert len(allow) == len(ALL_J3_WAREHOUSE_CODES) - len(WEBSITE_WAREHOUSE_DENYLIST)
+
+
+@pytest.mark.unit
+def test_is_website_warehouse():
+    assert is_website_warehouse("ALM") is True
+    assert is_website_warehouse("cen") is False
+    assert is_website_warehouse("MDL") is False
+    assert is_website_warehouse("") is False
+
+
+@pytest.mark.unit
+def test_sql_in_list_safe():
+    assert sql_in_list(["ALM", "SUR"]) == "'ALM', 'SUR'"
+    with pytest.raises(ValueError):
+        sql_in_list(["ALM'; DROP"])
+    with pytest.raises(ValueError):
+        sql_in_list([])
+
+
+@pytest.mark.unit
+def test_policy_summary_shape():
+    s = policy_summary()
+    assert "denylist" in s and "allowlist" in s
+    assert "default" in s["magento_msi_sources"]
+    assert "182" in s["issue"]
+
+
+@pytest.mark.unit
+def test_website_stock_sql_filters_denylist():
+    sql = build_website_stock_by_sku_sql(top_n=10)
+    lower = sql.lower()
+    assert "invdetalleexistencias" in lower
+    assert "admalmacen" in lower
+    assert "'CEN'" in sql or "'cen'" in sql.lower()
+    assert "website_qty" in lower
+    assert "excluded_qty" in lower
+    assert "TOP 10" in sql
+
+
+@pytest.mark.unit
+def test_impact_summary_sql():
+    sql = build_website_stock_impact_summary_sql()
+    assert "website_qty_sum" in sql
+    assert "excluded_qty_sum" in sql


### PR DESCRIPTION
## Summary

Implements the **website warehouse denylist** for [depositotrujillo.co#182](https://github.com/Trujillofa/depositotrujillo.co/issues/182) in this repo (source of truth for J3 data).

**Ops decisions encoded:**
- **Denylist:** `CEN`, `EXH`, `EXD`, `BDT`, `MDL`, `TRA` (garantías, exhibición, ajustes temporales, ML, COMITECAFE)
- **Keep** Magento dual MSI `default` + `CENTRO` (promos) — not changed here
- Magento never sees J3 codes; this repo measures correct website qty from `InvDetalleExistencias` and optionally patches MSI

### Live impact (dry-run against J3)

| Metric | Value |
|--------|------:|
| Website qty (allowlist) | ~1,579,333 |
| Excluded qty (denylist) | ~6,867 |
| All warehouses | ~1,586,199 |
| SKUs touched | 4,445 |

Some SKUs are **only** on denylisted bodegas (e.g. `0040030027` alambre: website 0, excluded 385).

### Code

- `website_warehouse_policy.py` — SSOT allow/deny lists
- `j3system_website_stock.py` — SQL + runner
- `depotru-website-stock` CLI — impact report, Magento compare, gated `--apply`
- `MagentoRestClient.post_source_items` — optional MSI write
- Docs: `docs/reference/website-warehouse-allowlist.md`

## Preferred ops path

1. Configure the **same denylist** in b2c.smart-business.app (stops bad aggregation at the feed)
2. Use `depotru-website-stock` to verify impact
3. Only `--apply` listed SKUs if intentionally shadowing B2C (feed may overwrite)

## Test plan

- [x] Unit tests `tests/analysis/test_website_warehouse_policy.py` (7 passed)
- [x] Live dry-run: `PYTHONPATH=src python -m business_analyzer.core.website_stock_cli --top-n 15`
- [ ] CI green
- [ ] (Optional) Magento compare with production token
- [ ] Apply denylist in B2C admin / vendor