### PR TITLE
feat(assistant): improve storefront routing from production chat log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Assistant routing quality (production chat log)**:
+  - Greeting-only turns return help without `platform.health`
+  - Product extract: `cotizar`, `ando buscando`, strip leading greeting/qty
+  - Bare product-name fallthrough → `catalog.search_products`
+  - Cart/checkout/pay intent → Spanish storefront ops reply (no product misroute)
+  - Branch phrasing: `dónde quede`, `sede principal`
+  - Guide patterns: tanque ajover/cotizar, lámina galvanizada, anticorr typos, sikagrout/grouting
 - **Website J3 warehouse allowlist** (depositotrujillo.co#182):
   - SSOT: `website_warehouse_policy` denylist CEN/EXH/EXD/BDT/MDL/TRA
   - SQL: website vs excluded stock from `InvDetalleExistencias`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -40,8 +40,10 @@ Platform adapters bridge them; Magento never free-form queries MSSQL.
 - [x] E2E affinity → `apply_crosssell_merge_bulk` dry-run + remote validate (no writes)
 - [x] Affinity **apply** on Magento (merge-only, 25+50 SKU batches; mostly already present)
 - [x] Magento `DepositoTrujillo_Assistant` widget module scaffolded (proxy + FAB; deploy to enable)
+- [x] Chat-log routing polish (greetings, bare product, cotizar, cart/pay, guide patterns)
 - [ ] Live sellable qty with production token (scoped)
 - [ ] LLM tool-calling on top of registry (replace stub router)
+- [ ] Named Cloudflare tunnel (`bff.depositotrujillo.co`) when account token available
 
 ### Phase 2 — CRM core
 

--- a/src/apps/api/v1.py
+++ b/src/apps/api/v1.py
@@ -93,6 +93,8 @@ class AssistantChatResponse(BaseModel):
     tools_used: List[str]
     grounded: bool
     mode: str
+    guide_id: Optional[str] = None
+    product_query: Optional[str] = None
 
 
 @router.get("/health")
@@ -173,6 +175,8 @@ async def assistant_chat(
         tools_used=resp.tools_used,
         grounded=resp.grounded,
         mode=resp.mode,
+        guide_id=resp.guide_id,
+        product_query=resp.product_query,
     )
 
 

--- a/src/modules/assistant/chat.py
+++ b/src/modules/assistant/chat.py
@@ -48,8 +48,54 @@ _BRANCH_RE = re.compile(
     r"\bsucursales?\b|"
     r"\bhorarios?\b|"
     r"\bubicaci[oó]n(?:es)?\b|"
-    r"d[oó]nde\s+est[aá]n|"
-    r"cu[aá]les\s+son\s+las\s+sedes"
+    r"d[oó]nde\s+(?:est[aá]n|est[aá]|queda|quede)|"
+    r"cu[aá]les\s+son\s+las\s+sedes|"
+    r"sede\s+principal"
+    r")",
+    re.I,
+)
+# Full-message greetings only (no product/job content).
+_GREETING_ONLY_RE = re.compile(
+    r"^\s*(?:"
+    r"hola(?:\s+(?:buenos?\s+d[ií]as|buenas?\s+(?:tardes|noches)|buenas))?|"
+    r"buenos?\s+d[ií]as|"
+    r"buen\s+d[ií]a|"
+    r"buenas?\s+(?:tardes|noches)|"
+    r"buenas|"
+    r"hello(?:\s+\w+)?|"
+    r"hi|"
+    r"hey|"
+    r"saludos"
+    r")[\s!.¡¿,?]*$",
+    re.I,
+)
+# Leading greeting on mixed turns: "HOLA ANDO BUSCANDO…"
+_LEADING_GREETING_RE = re.compile(
+    r"^\s*(?:"
+    r"hola|"
+    r"buenos?\s+d[ií]as|"
+    r"buen\s+d[ií]a|"
+    r"buenas?\s+(?:tardes|noches)|"
+    r"buenas|"
+    r"hello|"
+    r"hi|"
+    r"hey"
+    r")[\s,!.¡¿:]+",
+    re.I,
+)
+# Checkout / online payment — not a product search.
+_CART_PAY_RE = re.compile(
+    r"(?:"
+    r"\bpagar\b|"
+    r"\bpago\b|"
+    r"\bpagos?\b|"
+    r"\bcarrito\b|"
+    r"carro\s+de\s+compras|"
+    r"\bcheckout\b|"
+    r"pasarela\s+de\s+pago|"
+    r"medio\s+de\s+pago|"
+    r"pagar\s+por\s+internet|"
+    r"lo\s+que\s+tengo\s+en\s+el\s+carro"
     r")",
     re.I,
 )
@@ -62,15 +108,24 @@ _PRODUCT_QUERY_RE = re.compile(
     r"stock\s+(?:de\s+|del\s+)?(.+?)(?:\?|$)|"
     r"existencia\s+(?:de\s+|del\s+)?(.+?)(?:\?|$)|"
     r"busco\s+(.+?)(?:\?|$)|"
+    r"ando\s+buscando\s+(.+?)(?:\?|$)|"
+    r"buscando\s+(.+?)(?:\?|$)|"
+    r"cotizar\s+(?:un|una|unos|unas)?\s*(.+?)(?:\?|$)|"
     r"necesito\s+(?!material(?:es)?\s+para|cosas\s+para|productos?\s+para)(.+?)(?:\?|$)|"
     r"venden\s+(.+?)(?:\?|$)|"
     r"precio\s+(?:de\s+|del\s+)?(.+?)(?:\?|$)|"
-    r"me\s+recomiendan?\s+(.+?)(?:\?|$)"
+    r"me\s+recomiendan?\s+(.+?)(?:\?|$)|"
+    r"suministro[,\s]+(?:transporte[,\s]+)?(?:e\s+)?instalaci[oó]n\s+de\s+(.+?)(?:\?|$)"
     r")",
     re.I,
 )
 _STOP_QUERY = re.compile(
     r"\b(sku|sede|sucursal|horario|producto|productos|relacionad\w*|stock)\b",
+    re.I,
+)
+# Leading quantity: "15 rodillos profesional…"
+_LEADING_QTY_RE = re.compile(
+    r"^\s*\d+(?:[.,]\d+)?\s*(?:x\s*)?(?:und(?:s|ades?)?|unidades?)?\s+",
     re.I,
 )
 
@@ -84,6 +139,13 @@ _HELP_REPLY = (
     "No invento precios de costo ni datos de terceros."
 )
 
+_CART_REPLY = (
+    "Para pagar o finalizar lo que tienes en el carrito, usa el "
+    "checkout de la tienda en www.depositotrujillo.co (ícono del carrito). "
+    "Desde este chat no puedo cobrar ni ver tu carrito. "
+    "Si necesitas un producto, sedes u orientación para un trabajo, dímelo."
+)
+
 
 def _clean_product_query(raw: str) -> str:
     q = (raw or "").strip()
@@ -94,6 +156,7 @@ def _clean_product_query(raw: str) -> str:
         q,
         flags=re.I,
     ).strip()
+    q = _LEADING_QTY_RE.sub("", q).strip()
     q = re.sub(r"\s+(por\s+favor|pls|please)\s*$", "", q, flags=re.I).strip()
     if len(q) < 2 or _STOP_QUERY.search(q):
         return ""
@@ -103,9 +166,25 @@ def _clean_product_query(raw: str) -> str:
     return q[:80]
 
 
+def _strip_leading_greeting(text: str) -> str:
+    """Remove leading hola/buenas so mixed turns can product-route."""
+    return _LEADING_GREETING_RE.sub("", text or "", count=1).strip()
+
+
+def is_greeting_only(text: str) -> bool:
+    return bool(_GREETING_ONLY_RE.match((text or "").strip()))
+
+
+def is_cart_pay_intent(text: str) -> bool:
+    return bool(_CART_PAY_RE.search(text or ""))
+
+
 def extract_product_query(text: str) -> Optional[str]:
     """Pull a product name fragment from natural Spanish storefront questions."""
-    m = _PRODUCT_QUERY_RE.search(text or "")
+    t = _strip_leading_greeting(text or "")
+    if not t:
+        t = text or ""
+    m = _PRODUCT_QUERY_RE.search(t)
     if not m:
         return None
     for g in m.groups():
@@ -114,6 +193,35 @@ def extract_product_query(text: str) -> Optional[str]:
             if cleaned:
                 return cleaned
     return None
+
+
+def bare_product_query(text: str) -> Optional[str]:
+    """Treat free-text as a catalog query when it looks like a product name.
+
+    Used after explicit extract fails: «SDS anticorrisvo negro», «Lavaropas…».
+    """
+    t = _strip_leading_greeting(text or "")
+    t = (t or text or "").strip()
+    t = re.sub(r"[¿?¡!]+", "", t).strip()
+    if len(t) < 4:
+        return None
+    if is_greeting_only(t) or is_cart_pay_intent(t) or _BRANCH_RE.search(t):
+        return None
+    # Single short token with no letters of substance
+    if re.fullmatch(r"\d+", t):
+        return None
+    # Prefer messages that look like product names / specs, not long prose
+    cleaned = _clean_product_query(t)
+    if not cleaned or len(cleaned) < 4:
+        return None
+    # Skip pure help questions without a noun phrase
+    if re.match(
+        r"^(c[oó]mo|qu[eé]|por\s+qu[eé]|ayuda|help)\b",
+        cleaned,
+        flags=re.I,
+    ):
+        return None
+    return cleaned[:80]
 
 
 def _search_products(
@@ -322,6 +430,14 @@ def run_assistant_turn(req: ChatRequest) -> ChatResponse:
             mode="stub_tools",
         )
 
+    # Greeting-only: friendly help, no platform.health noise
+    if is_greeting_only(text):
+        return ChatResponse(
+            reply="¡Hola! " + _HELP_REPLY,
+            session_id=session_id,
+            mode="stub_tools",
+        )
+
     # Branches / store info
     if _BRANCH_RE.search(text):
         result = registry.call("info.branches", {}, context=ctx)
@@ -336,6 +452,14 @@ def run_assistant_turn(req: ChatRequest) -> ChatResponse:
             session_id=session_id,
             tools_used=tools_used,
             tool_results=tool_results,
+        )
+
+    # Cart / online payment (before product extract — "carro" ≠ product)
+    if is_cart_pay_intent(text):
+        return ChatResponse(
+            reply=_CART_REPLY,
+            session_id=session_id,
+            mode="stub_tools",
         )
 
     # Problem / project first (customer language)
@@ -361,7 +485,7 @@ def run_assistant_turn(req: ChatRequest) -> ChatResponse:
                 product_query=topic,
             )
 
-    # Product name search: "tienen cemento?", "busco varilla"
+    # Product name search: "tienen cemento?", "busco varilla", "cotizar un tanque"
     product_q = extract_product_query(text)
     if product_q:
         # If the product phrase is itself a problem phrase, prefer guide
@@ -369,6 +493,19 @@ def run_assistant_turn(req: ChatRequest) -> ChatResponse:
             guided = _reply_problem_guide(
                 registry, ctx, tools_used, tool_results, product_q
             )
+            if guided:
+                guide_reply, guide_id = guided
+                return ChatResponse(
+                    reply=guide_reply,
+                    session_id=session_id,
+                    tools_used=tools_used,
+                    tool_results=tool_results,
+                    guide_id=guide_id,
+                    product_query=product_q,
+                )
+        # Full message may match a guide even when extract is a product noun
+        if match_guide(text):
+            guided = _reply_problem_guide(registry, ctx, tools_used, tool_results, text)
             if guided:
                 guide_reply, guide_id = guided
                 return ChatResponse(
@@ -390,33 +527,53 @@ def run_assistant_turn(req: ChatRequest) -> ChatResponse:
             product_query=product_q,
         )
 
-    # Free-text fallback
-    if len(text) >= 12 and not _BRANCH_RE.search(text):
-        if not re.fullmatch(
-            r"(hola|buenas|buenos\s+d[ií]as|buenas\s+tardes|hey|hi)[\s!.]*",
-            text,
-            flags=re.I,
-        ):
-            topic = extract_problem_topic(text) or text[:80]
-            if looks_like_problem(text) or extract_problem_topic(text):
-                reply = _reply_problem_topic(
-                    registry, ctx, tools_used, tool_results, topic
-                )
+    # Problem topic free-text (no curated guide)
+    topic = extract_problem_topic(text)
+    if topic:
+        reply = _reply_problem_topic(registry, ctx, tools_used, tool_results, topic)
+        return ChatResponse(
+            reply=reply,
+            session_id=session_id,
+            tools_used=tools_used,
+            tool_results=tool_results,
+            product_query=topic,
+        )
+
+    # Bare product name / model / industrial phrase fallthrough
+    bare_q = bare_product_query(text)
+    if bare_q:
+        if match_guide(bare_q) or match_guide(text):
+            guided = _reply_problem_guide(
+                registry,
+                ctx,
+                tools_used,
+                tool_results,
+                text if match_guide(text) else bare_q,
+            )
+            if guided:
+                guide_reply, guide_id = guided
                 return ChatResponse(
-                    reply=reply,
+                    reply=guide_reply,
                     session_id=session_id,
                     tools_used=tools_used,
                     tool_results=tool_results,
-                    product_query=topic,
+                    guide_id=guide_id,
+                    product_query=bare_q,
                 )
+        reply = _reply_product_name_search(
+            registry, ctx, tools_used, tool_results, bare_q
+        )
+        return ChatResponse(
+            reply=reply,
+            session_id=session_id,
+            tools_used=tools_used,
+            tool_results=tool_results,
+            product_query=bare_q,
+        )
 
-    # Default help (no SKU language)
-    health = registry.call("platform.health", {}, context=ctx)
-    tools_used.append("platform.health")
-    tool_results.append({"tool": "platform.health", "result": health})
+    # Default help — no platform.health (noise in chat logs)
     return ChatResponse(
         reply=_HELP_REPLY,
         session_id=session_id,
-        tools_used=tools_used,
-        tool_results=tool_results,
+        mode="stub_tools",
     )

--- a/src/modules/assistant/problem_guides.py
+++ b/src/modules/assistant/problem_guides.py
@@ -390,7 +390,9 @@ GUIDES: Tuple[ProblemGuide, ...] = (
         title="Tanque de agua o almacenamiento",
         patterns=(
             r"tanque\s+de\s+agua",
-            r"tanque\s+(elevado|pl[aá]stico|polietileno)",
+            r"tanque\s+(elevado|pl[aá]stico|polietileno|ajover)",
+            r"tanque\s+ajover",
+            r"cotizar\s+(?:un|una|unos|unas)?\s*tanque",
             r"instalar\s+(un\s+)?tanque",
             r"\bpolietileno\b.*tanque|tanque.*\bpolietileno\b",
             r"almacenamiento\s+de\s+agua",
@@ -681,9 +683,10 @@ GUIDES: Tuple[ProblemGuide, ...] = (
         patterns=(
             r"pintar\s+(el\s+)?(metal|hierro|reja|port[oó]n)",
             r"\b[oó]xido\b",
-            r"anticorrosiv",
+            r"anticorr",  # anticorrosivo + typos (anticorrisvo)
             r"pintura\s+(para\s+)?(metal|hierro)",
             r"quitar\s+[oó]xido",
+            r"\bsds\b.*anticorr|anticorr.*\bsds\b",
         ),
         intro="Para pintar metal o tratar óxido suele usarse:",
         needs=(
@@ -779,6 +782,9 @@ GUIDES: Tuple[ProblemGuide, ...] = (
         title="Aditivos e impermeabilizantes de obra (tipo Sika)",
         patterns=(
             r"\bsika\b",
+            r"\bsikagrout\b",
+            r"\bgrouting\b",
+            r"grouting\s+de\s+nivelaci[oó]n",
             r"aditivo\s+(para\s+)?(mortero|concreto|impermeabil)",
             r"impermeabilizante\s+cementoso",
             r"hidr[oó]fugo",
@@ -930,10 +936,14 @@ GUIDES: Tuple[ProblemGuide, ...] = (
             r"cubierta\s+liviana",
             r"techo\s+de\s+l[aá]mina",
             r"l[aá]mina\s+(de\s+)?techo",
+            r"l[aá]mina\s+galvanizada",
+            r"l[aá]mina\s+cal(?:ibre)?\s*\d+",
+            r"lamina\s+galvanizada",
         ),
         intro="Para cubierta de zinc/lámina suele necesitarse:",
         needs=(
             ProductNeed("Láminas o tejas del perfil correcto", "teja zinc"),
+            ProductNeed("Lámina galvanizada (calibre según uso)", "lamina galvanizada"),
             ProductNeed("Tornillos para teja / autofijantes", "tornillo teja"),
             ProductNeed("Caballetes y remates", "caballete"),
             ProductNeed("Sellador o silicona para traslapes", "silicona"),
@@ -941,7 +951,7 @@ GUIDES: Tuple[ProblemGuide, ...] = (
                 "Cinta asfáltica o manto en uniones (si aplica)", "cinta asfaltica"
             ),
         ),
-        tip="Lleva la medida del traslape y la longitud de la caída de agua.",
+        tip="Lleva la medida del traslape y la longitud de la caída de agua. Para lámina, indica calibre y si es techo o cerramiento.",
     ),
     ProblemGuide(
         id="pozo_septico",

--- a/tests/platform/test_tools_and_assistant.py
+++ b/tests/platform/test_tools_and_assistant.py
@@ -100,6 +100,14 @@ def test_assistant_product_name_search_routes():
     assert extract_product_query("tienen cemento?") == "cemento"
     assert extract_product_query("stock de cemento") == "cemento"
     assert extract_product_query("busco varilla 1/2") == "varilla 1/2"
+    assert extract_product_query("cotizar un tanque ajover") is not None
+    assert (
+        "rodillo"
+        in (
+            extract_product_query('HOLA ANDO BUSCANDO 15 RODILLOS PROFESIONAL DE 4"')
+            or ""
+        ).lower()
+    )
 
     resp = run_assistant_turn(
         ChatRequest(message="tienen cemento?", audience=Audience.PUBLIC)
@@ -115,6 +123,99 @@ def test_assistant_product_name_search_routes():
         if "SKU" in line.upper()
     )
     assert "SKU" not in resp.reply
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_assistant_greeting_no_platform_health():
+    """Chat-log: greetings must not call platform.health."""
+    for msg in (
+        "Hola",
+        "buenas noches",
+        "buen día",
+        "hola buenos dias",
+        "hello mister",
+    ):
+        resp = run_assistant_turn(ChatRequest(message=msg, audience=Audience.PUBLIC))
+        assert "platform.health" not in resp.tools_used, msg
+        assert "asistente" in resp.reply.lower() or "depósito" in resp.reply.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_assistant_chat_log_product_and_guide_routes():
+    """Routes derived from production chat_log.jsonl unmatched turns."""
+    # Cotizar tanque → guide or catalog, never health
+    resp = run_assistant_turn(
+        ChatRequest(message="cotizar un tanque ajover", audience=Audience.PUBLIC)
+    )
+    assert "platform.health" not in resp.tools_used
+    assert (
+        resp.guide_id == "tanque_agua" or "catalog.search_products" in resp.tools_used
+    )
+    assert "tanque" in resp.reply.lower()
+
+    # Greeting + product search
+    resp = run_assistant_turn(
+        ChatRequest(
+            message='HOLA ANDO BUSCANDO 15 RODILLOS PROFESIONAL DE 4"',
+            audience=Audience.PUBLIC,
+        )
+    )
+    assert "platform.health" not in resp.tools_used
+    assert "catalog.search_products" in resp.tools_used
+    assert "rodillo" in resp.reply.lower() or "rodillos" in resp.reply.lower()
+
+    # Bare product / typo anticorrosivo → metal paint guide or catalog
+    resp = run_assistant_turn(
+        ChatRequest(message="SDS anticorrisvo negro", audience=Audience.PUBLIC)
+    )
+    assert "platform.health" not in resp.tools_used
+    assert (
+        resp.guide_id == "pintura_metal" or "catalog.search_products" in resp.tools_used
+    )
+
+    # Lámina galvanizada
+    resp = run_assistant_turn(
+        ChatRequest(
+            message="necesito un lamina galvanizada calibre 12",
+            audience=Audience.PUBLIC,
+        )
+    )
+    assert "platform.health" not in resp.tools_used
+    assert resp.guide_id == "teja_zinc" or "catalog.search_products" in resp.tools_used
+    assert (
+        "lám" in resp.reply.lower()
+        or "lamina" in resp.reply.lower()
+        or "zinc" in resp.reply.lower()
+        or "catálogo" in resp.reply.lower()
+        or "productos" in resp.reply.lower()
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_assistant_cart_pay_not_product_search():
+    resp = run_assistant_turn(
+        ChatRequest(
+            message="Necesito pagar por internet lo que tengo en el carro me ayudas",
+            audience=Audience.PUBLIC,
+        )
+    )
+    assert "catalog.search_products" not in resp.tools_used
+    assert "platform.health" not in resp.tools_used
+    assert "carrito" in resp.reply.lower() or "checkout" in resp.reply.lower()
+    assert "pagar" in resp.reply.lower() or "tienda" in resp.reply.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_assistant_sede_quede_principal():
+    resp = run_assistant_turn(
+        ChatRequest(message="Dónde quede la sede principal", audience=Audience.PUBLIC)
+    )
+    assert "info.branches" in resp.tools_used
+    assert "Sede Principal" in resp.reply or "sedes" in resp.reply.lower()
 
 
 @pytest.mark.unit
@@ -186,8 +287,12 @@ def test_assistant_problem_tanque_reply_no_sku():
 
 
 @pytest.mark.unit
-def test_v1_api_tools_and_chat():
+def test_v1_api_tools_and_chat(monkeypatch: pytest.MonkeyPatch):
     from api import app
+
+    # Sourced deploy/bff/env.bff must not force 401 in unit tests
+    monkeypatch.delenv("PLATFORM_API_KEYS", raising=False)
+    monkeypatch.delenv("API_KEY", raising=False)
 
     client = TestClient(app)
     r = client.get("/v1/health")
@@ -206,6 +311,9 @@ def test_v1_api_tools_and_chat():
     body = r3.json()
     assert "FED" in body["reply"] or "sedes" in body["reply"].lower()
     assert body["grounded"] is True
+    # Response schema includes optional routing diagnostics
+    assert "guide_id" in body
+    assert "product_query" in body
 
     r4 = client.get("/v1/affinity/contract")
     assert r4.status_code == 200


### PR DESCRIPTION
## Summary
- Improve storefront assistant routing from production `chat_log.jsonl` failures (greetings, cart/pay, cotizar, bare product names, branch phrasing).
- Expand problem-guide patterns (tanque ajover, lámina galvanizada, anticorrosivo typos, sikagrout).
- Expose `guide_id` and `product_query` on `POST /v1/assistant/chat`.
- Add chat-log-driven unit tests; harden API tests against sourced `PLATFORM_API_KEYS`.

## Test plan
- [x] `pytest tests/platform/test_tools_and_assistant.py tests/platform/test_assistant_logging.py -q`
- [x] BFF restarted locally; smoke routes for Hola / cotizar tanque / cart / sedes
- [ ] CI green on this PR

## Out of scope
- Named Cloudflare tunnel (needs token)
- Magento live sellable qty (needs REST token)
- LLM tool-calling