### PR TITLE
feat(assistant): hybrid stub-first LLM tool-calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Hybrid stub-first LLM assistant** (`ASSISTANT_LLM=1`):
+  - Confident stub paths (greetings, sedes, cart, guides, product search) skip LLM
+  - Generic-help fallthrough uses Grok tool loop (`info.branches`, `catalog.search_products`)
+  - `mode=llm_tools` when LLM answers; fail-soft back to stub help
+  - Module: `modules.assistant.llm_router`
 - **Assistant routing quality (production chat log)**:
   - Greeting-only turns return help without `platform.health`
   - Product extract: `cotizar`, `ando buscando`, strip leading greeting/qty

--- a/deploy/bff/env.bff.example
+++ b/deploy/bff/env.bff.example
@@ -13,6 +13,11 @@ BFF_PORT=8000
 # MAGENTO_ACCESS_TOKEN=
 # MAGENTO_STOREFRONT_URL=https://www.depositotrujillo.co
 
+# Hybrid assistant: LLM only when stub falls through to generic help
+# Requires GROK_API_KEY (project .env is fine). Default off.
+# ASSISTANT_LLM=1
+# ASSISTANT_LLM_MODEL=grok-4-1-fast-non-reasoning
+
 # --- Tunnel mode ---
 # Preferred (stable hostname): Cloudflare named tunnel token from Zero Trust dashboard
 # CLOUDFLARE_TUNNEL_TOKEN=

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -81,6 +81,24 @@ Response:
 
 Browser only calls same-origin `/assistant/chat/post` (form_key + message). API key never leaves Magento.
 
+### Hybrid stub-first LLM
+
+Routing is **deterministic first** (greetings, sedes, cart, problem guides, product
+name search). Only when the stub would return generic help does the optional LLM
+run, calling **public** registry tools (`info.branches`, `catalog.search_products`).
+
+```bash
+# Enable on BFF (uses GROK_API_KEY from .env)
+export ASSISTANT_LLM=1
+# optional:
+# export ASSISTANT_LLM_MODEL=grok-4-1-fast-non-reasoning
+systemctl --user restart depotru-bff
+```
+
+- Default **off** (CI / no key → same stub-only behavior).
+- Response `mode`: `stub_tools` | `llm_tools`.
+- Never invents prices/stock; no SKU language; no attribution tools.
+
 ### Chat question log (JSONL)
 
 Each `POST /v1/assistant/chat` appends one line (never fails the request):
@@ -143,9 +161,9 @@ Reports: `reports/AFFINITY_E2E_DRY_RUN_*.md`
 
 ## Next
 
-1. Deploy + enable `DepositoTrujillo_Assistant` on Magento (BFF must be reachable from origin)
-2. Live sellable qty (`MAGENTO_*` on BFF)
-3. LLM tool-calling on assistant stub
+1. Enable `ASSISTANT_LLM=1` on production BFF when ready (Grok key in `.env`)
+2. Live sellable qty (`MAGENTO_*` on BFF) + optional stock tool in LLM allowlist
+3. Named Cloudflare tunnel when account token available
 4. CRM / WMS modules
 5. Split `AIVanna` routing into tools
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,8 +41,8 @@ Platform adapters bridge them; Magento never free-form queries MSSQL.
 - [x] Affinity **apply** on Magento (merge-only, 25+50 SKU batches; mostly already present)
 - [x] Magento `DepositoTrujillo_Assistant` widget module scaffolded (proxy + FAB; deploy to enable)
 - [x] Chat-log routing polish (greetings, bare product, cotizar, cart/pay, guide patterns)
+- [x] Hybrid stub-first LLM tool-calling (`ASSISTANT_LLM=1`, public tools only)
 - [ ] Live sellable qty with production token (scoped)
-- [ ] LLM tool-calling on top of registry (replace stub router)
 - [ ] Named Cloudflare tunnel (`bff.depositotrujillo.co`) when account token available
 
 ### Phase 2 — CRM core

--- a/src/depotru_tools/builtins.py
+++ b/src/depotru_tools/builtins.py
@@ -2,34 +2,142 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional
 
 from depotru_kernel.attribution import resolve_seller
 from depotru_kernel.auth import ToolScope
 from depotru_kernel.documents import CANONICAL_EXCLUDED_DOCUMENT_CODES
 from depotru_tools.registry import ToolContext, ToolRegistry, ToolSpec
 
-# Public store info (static; Magento theme can override later via config).
+# Public storefront locations (SSOT for customers: depositotrujillo.co/bodegas).
+# Do not expose ERP document codes (FED/FEF/FET) to customers.
+_PUBLIC_HOURS = (
+    "Lunes a sábado (no festivos): 8:00 a.m. a 12:00 m. y 2:00 p.m. a 5:00 p.m."
+)
+_BODEGAS_URL = "https://www.depositotrujillo.co/bodegas"
+
 BRANCHES = [
     {
-        "code": "FED",
-        "name": "Sede Principal",
+        "name": "Bodega del Sur",
+        "kind": "bodega",
         "city": "Neiva",
-        "note": "Sucursal comercial (DocumentosCodigo FED)",
+        "department": "Huila",
+        "address": "Calle 24 con Carrera 20, Neiva, Huila",
+        "phone": None,
+        "whatsapp": None,
+        "hours": _PUBLIC_HOURS,
+        "maps_url": "https://www.google.com/maps/search/?api=1&query=2.901117,-75.282284",
+        "note": "La más grande y amplia de Neiva; almacenamiento y distribución.",
     },
     {
-        "code": "FEF",
-        "name": "Sede Ferias / alterna",
+        "name": "Bodega Mangueras",
+        "kind": "bodega",
         "city": "Neiva",
-        "note": "Sucursal comercial",
+        "department": "Huila",
+        "address": "Calle 23 Sur # 6, Neiva, Huila",
+        "phone": None,
+        "whatsapp": None,
+        "hours": _PUBLIC_HOURS,
+        "maps_url": "https://www.google.com/maps/search/?api=1&query=2.907155,-75.284999",
+        "note": (
+            "Tanques plásticos, pozos sépticos, mallas, mangueras de riego y afines."
+        ),
     },
     {
-        "code": "FET",
-        "name": "Calle 5",
+        "name": "Bodega 6",
+        "kind": "bodega",
         "city": "Neiva",
-        "note": "Sucursal comercial",
+        "department": "Huila",
+        "address": (
+            "Zona Recrificadora Santofimio (Carrera 3 / Pasaje Camacho), Neiva, Huila"
+        ),
+        "phone": None,
+        "whatsapp": None,
+        "hours": _PUBLIC_HOURS,
+        "maps_url": "https://www.google.com/maps/search/?api=1&query=2.922615,-75.289394",
+        "note": "Punto de la red de bodegas en el centro de Neiva.",
+    },
+    {
+        "name": "Sede Distribuciones (Sede Quinta / Calle 5)",
+        "kind": "sede",
+        "city": "Neiva",
+        "department": "Huila",
+        "address": "Calle 5 # 4-55, Neiva, Huila",
+        "phone": "3152091771",
+        "whatsapp": "3152091771",
+        "hours": _PUBLIC_HOURS,
+        "maps_url": "https://www.google.com/maps/search/?api=1&query=2.924377,-75.288068",
+        "note": "Sede comercial Calle 5 (también referida como Sede Quinta).",
     },
 ]
+
+STORE_CONTACT = {
+    "whatsapp": "3168688799",
+    "customer_service_phone": "3009109549",
+    "hours": _PUBLIC_HOURS,
+    "more_info_url": _BODEGAS_URL,
+    "city": "Neiva",
+    "department": "Huila",
+    "legal_address": "Calle 4 # 2-20, Neiva, Huila (oficina / razón social)",
+}
+
+
+def format_branches_customer_reply(
+    payload: Optional[Mapping[str, Any]] = None,
+) -> str:
+    """Spanish customer-facing list with address, hours, phones and maps."""
+    data = dict(payload or {})
+    branches = data.get("branches") or BRANCHES
+    contact = data.get("contact") or STORE_CONTACT
+    lines = [
+        "Nuestras sedes y bodegas en Neiva (Huila):",
+        "",
+    ]
+    for b in branches:
+        if not isinstance(b, Mapping):
+            continue
+        name = (b.get("name") or "").strip()
+        if not name:
+            continue
+        lines.append(f"• {name}")
+        address = (b.get("address") or "").strip()
+        if address:
+            lines.append(f"  Dirección: {address}")
+        hours = (b.get("hours") or contact.get("hours") or "").strip()
+        if hours:
+            lines.append(f"  Horario: {hours}")
+        phone = (b.get("phone") or "").strip()
+        if phone:
+            pretty = _pretty_phone(phone)
+            lines.append(f"  Teléfono: {pretty}")
+        wa = (b.get("whatsapp") or "").strip()
+        if wa and wa != phone:
+            lines.append(f"  WhatsApp sede: {_pretty_phone(wa)}")
+        maps_url = (b.get("maps_url") or "").strip()
+        if maps_url:
+            lines.append(f"  Mapa: {maps_url}")
+        note = (b.get("note") or "").strip()
+        if note:
+            lines.append(f"  Nota: {note}")
+        lines.append("")
+
+    wa_main = (contact.get("whatsapp") or "").strip()
+    svc = (contact.get("customer_service_phone") or "").strip()
+    more = (contact.get("more_info_url") or _BODEGAS_URL).strip()
+    if wa_main:
+        lines.append(f"WhatsApp general: {_pretty_phone(wa_main)}")
+    if svc:
+        lines.append(f"Servicio al cliente: {_pretty_phone(svc)}")
+    if more:
+        lines.append(f"Más información y mapas: {more}")
+    return "\n".join(lines).strip()
+
+
+def _pretty_phone(raw: str) -> str:
+    digits = "".join(c for c in raw if c.isdigit())
+    if len(digits) == 10:
+        return f"{digits[:3]} {digits[3:6]} {digits[6:]}"
+    return raw.strip()
 
 
 def _tool_platform_health(ctx: ToolContext, params: Mapping[str, Any]) -> dict:
@@ -43,7 +151,12 @@ def _tool_platform_health(ctx: ToolContext, params: Mapping[str, Any]) -> dict:
 
 
 def _tool_branches_info(ctx: ToolContext, params: Mapping[str, Any]) -> dict:
-    return {"branches": BRANCHES, "locale": "es_CO"}
+    return {
+        "branches": BRANCHES,
+        "contact": STORE_CONTACT,
+        "locale": "es_CO",
+        "source": _BODEGAS_URL,
+    }
 
 
 def _tool_resolve_seller(ctx: ToolContext, params: Mapping[str, Any]) -> dict:
@@ -252,7 +365,10 @@ def register_builtin_tools(registry: ToolRegistry) -> None:
     registry.register(
         ToolSpec(
             name="info.branches",
-            description="List commercial branch / sede codes",
+            description=(
+                "List storefront sedes/bodegas with full address, hours, "
+                "phones and map links (Neiva, Huila)"
+            ),
             scope=ToolScope.PUBLIC_INFO,
             handler=_tool_branches_info,
             public_safe=True,

--- a/src/depotru_tools/builtins.py
+++ b/src/depotru_tools/builtins.py
@@ -26,7 +26,11 @@ BRANCHES = [
         "phone": None,
         "whatsapp": None,
         "hours": _PUBLIC_HOURS,
-        "maps_url": "https://www.google.com/maps/search/?api=1&query=2.901117,-75.282284",
+        # Google place: Depósito Trujillo @ Cl. 24 & Cra. 20
+        "maps_url": (
+            "https://www.google.com/maps/place/Deposito+Trujillo/"
+            "@2.9008497,-75.279817,17z"
+        ),
         "note": "La más grande y amplia de Neiva; almacenamiento y distribución.",
     },
     {
@@ -48,13 +52,15 @@ BRANCHES = [
         "kind": "bodega",
         "city": "Neiva",
         "department": "Huila",
-        "address": (
-            "Zona Recrificadora Santofimio (Carrera 3 / Pasaje Camacho), Neiva, Huila"
-        ),
+        "address": "Recrificadora Santofimio, Neiva, Huila",
         "phone": None,
         "whatsapp": None,
         "hours": _PUBLIC_HOURS,
-        "maps_url": "https://www.google.com/maps/search/?api=1&query=2.922615,-75.289394",
+        # Google place: Recrificadora Santofimio
+        "maps_url": (
+            "https://www.google.com/maps/place/Recrificadora+Santofimio/"
+            "@2.9223815,-75.2892973,17z"
+        ),
         "note": "Punto de la red de bodegas en el centro de Neiva.",
     },
     {

--- a/src/modules/assistant/chat.py
+++ b/src/modules/assistant/chat.py
@@ -37,9 +37,11 @@ class ChatResponse:
     tools_used: List[str] = field(default_factory=list)
     tool_results: List[Dict[str, Any]] = field(default_factory=list)
     grounded: bool = True
-    mode: str = "stub_tools"
+    mode: str = "stub_tools"  # stub_tools | llm_tools
     guide_id: Optional[str] = None
     product_query: Optional[str] = None
+    # Internal: True only for generic-help stub path → hybrid may call LLM
+    llm_eligible: bool = False
 
 
 _BRANCH_RE = re.compile(
@@ -199,6 +201,7 @@ def bare_product_query(text: str) -> Optional[str]:
     """Treat free-text as a catalog query when it looks like a product name.
 
     Used after explicit extract fails: «SDS anticorrisvo negro», «Lavaropas…».
+    Long free-form prose is left for hybrid LLM (not forced through catalog).
     """
     t = _strip_leading_greeting(text or "")
     t = (t or text or "").strip()
@@ -214,12 +217,18 @@ def bare_product_query(text: str) -> Optional[str]:
     cleaned = _clean_product_query(t)
     if not cleaned or len(cleaned) < 4:
         return None
-    # Skip pure help questions without a noun phrase
+    # Skip pure help questions / free-form intents (hybrid LLM path)
     if re.match(
-        r"^(c[oó]mo|qu[eé]|por\s+qu[eé]|ayuda|help)\b",
+        r"^(c[oó]mo|qu[eé]|por\s+qu[eé]|ayuda|help|quiero|quisiera|"
+        r"me\s+gustar[ií]a|ayúdame|ayudame|podr[ií]as|me\s+puedes|"
+        r"explica|recomi[eé]ndame|necesito\s+ayuda)\b",
         cleaned,
         flags=re.I,
     ):
+        return None
+    # Long prose (many tokens, no clear product phrase) → LLM-eligible help
+    words = cleaned.split()
+    if len(words) > 10:
         return None
     return cleaned[:80]
 
@@ -410,8 +419,11 @@ def _reply_product_name_search(
     return reply
 
 
-def run_assistant_turn(req: ChatRequest) -> ChatResponse:
-    """Deterministic tool-routing for public/customer audiences."""
+def run_stub_turn(req: ChatRequest) -> ChatResponse:
+    """Deterministic tool-routing for public/customer audiences.
+
+    Sets ``llm_eligible=True`` only on generic help (hybrid may escalate).
+    """
     session_id = req.session_id or str(uuid.uuid4())
     registry = get_default_registry()
     ctx = ToolContext(audience=req.audience, request_id=session_id)
@@ -571,9 +583,47 @@ def run_assistant_turn(req: ChatRequest) -> ChatResponse:
             product_query=bare_q,
         )
 
-    # Default help — no platform.health (noise in chat logs)
+    # Default help — LLM-eligible (hybrid may escalate)
     return ChatResponse(
         reply=_HELP_REPLY,
         session_id=session_id,
         mode="stub_tools",
+        llm_eligible=True,
+    )
+
+
+def run_assistant_turn(req: ChatRequest) -> ChatResponse:
+    """Hybrid: deterministic stub first; LLM tools only on generic-help fallback."""
+    stub = run_stub_turn(req)
+    if not stub.llm_eligible:
+        return stub
+
+    from modules.assistant import llm_router
+
+    if not llm_router.llm_enabled():
+        return stub
+
+    registry = get_default_registry()
+    llm_out = llm_router.run_llm_turn(
+        message=(req.message or "").strip(),
+        session_id=stub.session_id,
+        audience=req.audience,
+        registry=registry,
+        locale=req.locale,
+    )
+    if not llm_out:
+        return stub
+
+    reply, tools_used, tool_results = llm_out
+    if not reply:
+        return stub
+
+    return ChatResponse(
+        reply=reply,
+        session_id=stub.session_id,
+        tools_used=tools_used,
+        tool_results=tool_results,
+        grounded=True,
+        mode="llm_tools",
+        llm_eligible=False,
     )

--- a/src/modules/assistant/chat.py
+++ b/src/modules/assistant/chat.py
@@ -47,12 +47,18 @@ class ChatResponse:
 _BRANCH_RE = re.compile(
     r"(?:"
     r"\bsedes?\b|"  # sede / sedes
+    r"\bbodegas?\b|"
+    r"\balmacenes?\b|"
     r"\bsucursales?\b|"
     r"\bhorarios?\b|"
     r"\bubicaci[oó]n(?:es)?\b|"
     r"d[oó]nde\s+(?:est[aá]n|est[aá]|queda|quede)|"
     r"cu[aá]les\s+son\s+las\s+sedes|"
-    r"sede\s+principal"
+    r"sede\s+principal|"
+    r"sede\s+quinta|"
+    r"bodega\s+del\s+sur|"
+    r"bodega\s+mangueras|"
+    r"bodega\s*6\b"
     r")",
     re.I,
 )
@@ -450,15 +456,16 @@ def run_stub_turn(req: ChatRequest) -> ChatResponse:
             mode="stub_tools",
         )
 
-    # Branches / store info
+    # Branches / bodegas / store info (full address — see /bodegas)
     if _BRANCH_RE.search(text):
+        from depotru_tools.builtins import format_branches_customer_reply
+
         result = registry.call("info.branches", {}, context=ctx)
         tools_used.append("info.branches")
         tool_results.append({"tool": "info.branches", "result": result})
-        lines = [
-            f"- {b['name']} ({b.get('city', '')})" for b in result.get("branches", [])
-        ]
-        reply = "Nuestras sedes comerciales:\n" + "\n".join(lines)
+        reply = format_branches_customer_reply(
+            result if isinstance(result, dict) else None
+        )
         return ChatResponse(
             reply=reply,
             session_id=session_id,

--- a/src/modules/assistant/llm_router.py
+++ b/src/modules/assistant/llm_router.py
@@ -1,0 +1,305 @@
+"""LLM tool-calling for storefront assistant (hybrid fallback path).
+
+Only used when the deterministic stub would return generic help.
+Tools execute exclusively through the platform registry with public audience.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from depotru_kernel.auth import Audience
+from depotru_tools.registry import (
+    ToolContext,
+    ToolNotFoundError,
+    ToolPermissionError,
+    ToolRegistry,
+)
+
+logger = logging.getLogger(__name__)
+
+# v1 allowlist — never expose SKU-affinity, health noise, or stock invent risk
+_LLM_TOOL_ALLOWLIST = frozenset(
+    {
+        "info.branches",
+        "catalog.search_products",
+    }
+)
+
+_DEFAULT_MODEL = "grok-4-1-fast-non-reasoning"
+_GROK_BASE_URL = "https://api.x.ai/v1"
+_MAX_ROUNDS = 3
+_TIMEOUT_SEC = 25.0
+
+_SYSTEM_PROMPT = """Eres el asistente de Depósito Trujillo (ferretería y materiales, Neiva, Colombia).
+
+Reglas:
+- Responde en español colombiano, breve y claro.
+- Usa SOLO las herramientas disponibles para datos de sedes o productos del catálogo.
+- NUNCA inventes precios, stock, costos ni datos de terceros.
+- NUNCA muestres códigos SKU al cliente; habla de nombres de productos y tipos de material.
+- Si no hay resultados de herramientas, dilo y sugiere reformular o visitar una sede.
+- Para trabajos de casa (gotera, pintar, plomería) sugiere materiales útiles y ofrece buscar por nombre.
+- No digas que eres un modelo de IA genérico; eres el asistente de la tienda.
+"""
+
+_SKU_LINE_RE = re.compile(r"(?i)\bsku\b\s*[:=]?\s*\S+")
+
+
+def llm_enabled() -> bool:
+    """True when ASSISTANT_LLM is on and a Grok/xAI key is present."""
+    flag = (os.getenv("ASSISTANT_LLM") or "").strip().lower()
+    if flag not in ("1", "true", "yes", "on"):
+        return False
+    key = (os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY") or "").strip()
+    return bool(key) and not key.startswith("your-")
+
+
+def _api_key() -> str:
+    return (os.getenv("GROK_API_KEY") or os.getenv("XAI_API_KEY") or "").strip()
+
+
+def _model_name() -> str:
+    return (
+        os.getenv("ASSISTANT_LLM_MODEL") or _DEFAULT_MODEL
+    ).strip() or _DEFAULT_MODEL
+
+
+def tools_for_llm(registry: ToolRegistry, audience: Audience) -> List[Dict[str, Any]]:
+    """OpenAI-compatible tool definitions from the registry (allowlisted)."""
+    out: List[Dict[str, Any]] = []
+    for item in registry.list_tools(audience=audience):
+        name = item.get("name") or ""
+        if name not in _LLM_TOOL_ALLOWLIST:
+            continue
+        props: Dict[str, Any] = {}
+        required: List[str] = []
+        raw_params = item.get("parameters") or {}
+        if isinstance(raw_params, Mapping):
+            for pname, pdesc in raw_params.items():
+                if pname == "limit":
+                    props[pname] = {
+                        "type": "integer",
+                        "description": str(pdesc),
+                    }
+                else:
+                    props[pname] = {
+                        "type": "string",
+                        "description": str(pdesc),
+                    }
+                if pname in ("query",):
+                    required.append(pname)
+        parameters: Dict[str, Any] = {
+            "type": "object",
+            "properties": props,
+            "additionalProperties": False,
+        }
+        if required:
+            parameters["required"] = required
+        out.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": item.get("description") or name,
+                    "parameters": parameters,
+                },
+            }
+        )
+    return out
+
+
+def sanitize_customer_reply(text: str) -> str:
+    """Drop accidental SKU mentions from model text."""
+    lines = []
+    for line in (text or "").splitlines():
+        if _SKU_LINE_RE.search(line) and "sku" in line.lower():
+            cleaned = _SKU_LINE_RE.sub("", line).strip(" -–—:\t")
+            if cleaned:
+                lines.append(cleaned)
+            continue
+        lines.append(line)
+    return "\n".join(lines).strip()
+
+
+def _parse_tool_args(raw: Any) -> Dict[str, Any]:
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return dict(raw)
+    if isinstance(raw, str):
+        raw = raw.strip()
+        if not raw:
+            return {}
+        try:
+            data = json.loads(raw)
+            return data if isinstance(data, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _execute_tool(
+    registry: ToolRegistry,
+    ctx: ToolContext,
+    name: str,
+    params: Mapping[str, Any],
+) -> Tuple[Any, Optional[str]]:
+    """Return (result, error_message)."""
+    if name not in _LLM_TOOL_ALLOWLIST:
+        return None, f"Tool not allowed: {name}"
+    try:
+        result = registry.call(name, params, context=ctx)
+        return result, None
+    except ToolNotFoundError:
+        return None, f"Unknown tool: {name}"
+    except ToolPermissionError as exc:
+        return None, str(exc)
+    except Exception as exc:  # noqa: BLE001 — surface to model, never crash chat
+        logger.warning("assistant LLM tool %s failed: %s", name, exc)
+        return None, f"Tool error: {exc}"
+
+
+def run_llm_turn(
+    *,
+    message: str,
+    session_id: str,
+    audience: Audience,
+    registry: ToolRegistry,
+    locale: str = "es_CO",
+) -> Optional[Tuple[str, List[str], List[Dict[str, Any]]]]:
+    """Run OpenAI-compatible tool loop.
+
+    Returns (reply, tools_used, tool_results) or None on failure / disabled.
+    """
+    if not llm_enabled():
+        return None
+
+    tools = tools_for_llm(registry, audience)
+    if not tools:
+        return None
+
+    try:
+        from openai import OpenAI
+    except ImportError:
+        logger.warning("openai package missing; assistant LLM disabled")
+        return None
+
+    try:
+        client = OpenAI(
+            api_key=_api_key(),
+            base_url=_GROK_BASE_URL,
+            timeout=_TIMEOUT_SEC,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("assistant LLM client init failed: %s", exc)
+        return None
+
+    ctx = ToolContext(audience=audience, request_id=session_id)
+    tools_used: List[str] = []
+    tool_results: List[Dict[str, Any]] = []
+
+    # OpenAI SDK message types are overly strict for dynamic tool loops
+    messages: List[Any] = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": f"(locale={locale}) {message}",
+        },
+    ]
+    tools_param: Any = tools
+
+    try:
+        for _round in range(_MAX_ROUNDS):
+            response = client.chat.completions.create(
+                model=_model_name(),
+                messages=messages,
+                tools=tools_param,
+                tool_choice="auto",
+                temperature=0.3,
+            )
+            choice = response.choices[0]
+            msg = choice.message
+            raw_calls = list(msg.tool_calls or [])
+
+            if not raw_calls:
+                content = (msg.content or "").strip()
+                if not content:
+                    return None
+                return sanitize_customer_reply(content), tools_used, tool_results
+
+            # Append assistant message with tool_calls for the API protocol
+            tc_payloads = []
+            for tc in raw_calls:
+                fn = getattr(tc, "function", None)
+                if fn is None:
+                    continue
+                tc_payloads.append(
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": getattr(fn, "name", "") or "",
+                            "arguments": getattr(fn, "arguments", None) or "{}",
+                        },
+                    }
+                )
+            if not tc_payloads:
+                content = (msg.content or "").strip()
+                if not content:
+                    return None
+                return sanitize_customer_reply(content), tools_used, tool_results
+
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": msg.content or None,
+                    "tool_calls": tc_payloads,
+                }
+            )
+
+            for tc_p in tc_payloads:
+                fn = tc_p["function"]
+                name = fn.get("name") or ""
+                params = _parse_tool_args(fn.get("arguments"))
+                result, err = _execute_tool(registry, ctx, name, params)
+                tools_used.append(name)
+                payload = {"error": err} if err else {"result": _jsonable(result)}
+                tool_results.append({"tool": name, "result": payload})
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tc_p["id"],
+                        "content": json.dumps(payload, ensure_ascii=False, default=str)[
+                            :8000
+                        ],
+                    }
+                )
+
+        # Final round without tools if we exhausted tool rounds
+        response = client.chat.completions.create(
+            model=_model_name(),
+            messages=messages,
+            temperature=0.3,
+        )
+        content = (response.choices[0].message.content or "").strip()
+        if not content:
+            return None
+        return sanitize_customer_reply(content), tools_used, tool_results
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("assistant LLM turn failed: %s", exc)
+        return None
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [_jsonable(v) for v in value]
+    return str(value)

--- a/src/modules/assistant/llm_router.py
+++ b/src/modules/assistant/llm_router.py
@@ -39,9 +39,11 @@ _SYSTEM_PROMPT = """Eres el asistente de Depósito Trujillo (ferretería y mater
 
 Reglas:
 - Responde en español colombiano, breve y claro.
-- Usa SOLO las herramientas disponibles para datos de sedes o productos del catálogo.
-- NUNCA inventes precios, stock, costos ni datos de terceros.
-- NUNCA muestres códigos SKU al cliente; habla de nombres de productos y tipos de material.
+- Usa SOLO las herramientas disponibles para datos de sedes/bodegas o productos del catálogo.
+- Si preguntan por sedes, bodegas, dirección o horarios, llama info.branches y repite
+  dirección, horario, teléfono/WhatsApp y enlace de mapa de cada punto (no resumas a solo el nombre).
+- NUNCA inventes precios, stock, costos, direcciones ni datos de terceros.
+- NUNCA muestres códigos SKU ni códigos internos ERP (FED/FEF/FET) al cliente.
 - Si no hay resultados de herramientas, dilo y sugiere reformular o visitar una sede.
 - Para trabajos de casa (gotera, pintar, plomería) sugiere materiales útiles y ofrece buscar por nombre.
 - No digas que eres un modelo de IA genérico; eres el asistente de la tienda.

--- a/tests/platform/test_assistant_llm.py
+++ b/tests/platform/test_assistant_llm.py
@@ -1,0 +1,198 @@
+"""Hybrid stub-first LLM assistant tests (mocked LLM, no network)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from depotru_kernel.auth import Audience
+from depotru_tools.registry import reset_default_registry
+from modules.assistant import llm_router
+from modules.assistant.chat import ChatRequest, run_assistant_turn, run_stub_turn
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    reset_default_registry()
+    yield
+    reset_default_registry()
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_llm_disabled_by_default(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("ASSISTANT_LLM", raising=False)
+    monkeypatch.setenv("GROK_API_KEY", "xai-test-key")
+    assert llm_router.llm_enabled() is False
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_llm_enabled_requires_flag_and_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ASSISTANT_LLM", "1")
+    monkeypatch.delenv("GROK_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    assert llm_router.llm_enabled() is False
+
+    monkeypatch.setenv("GROK_API_KEY", "xai-test-key")
+    assert llm_router.llm_enabled() is True
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_stub_confident_paths_do_not_call_llm(monkeypatch: pytest.MonkeyPatch):
+    """Greetings / guides / sedes never hit the LLM."""
+    monkeypatch.setenv("ASSISTANT_LLM", "1")
+    monkeypatch.setenv("GROK_API_KEY", "xai-test-key")
+
+    called: List[str] = []
+
+    def boom(**_kwargs: Any):
+        called.append("llm")
+        raise AssertionError("LLM must not run for confident stub")
+
+    monkeypatch.setattr(llm_router, "run_llm_turn", boom)
+
+    for msg in (
+        "Hola",
+        "tengo una gotera en el techo",
+        "¿dónde están las sedes?",
+        "tienen cemento?",
+        "Necesito pagar por internet lo que tengo en el carro",
+    ):
+        resp = run_assistant_turn(ChatRequest(message=msg, audience=Audience.PUBLIC))
+        assert resp.mode == "stub_tools", msg
+        assert resp.llm_eligible is False, msg
+
+    assert called == []
+
+
+# Free-form intent that must not match a curated guide (→ LLM-eligible help)
+_FREEFORM = "quiero armar un closet empotrado económico con puertas corredizas"
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_stub_fallback_llm_eligible_when_disabled(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("ASSISTANT_LLM", raising=False)
+    # Free-form intent → generic help when LLM off
+    stub = run_stub_turn(ChatRequest(message=_FREEFORM, audience=Audience.PUBLIC))
+    assert stub.llm_eligible is True
+    assert stub.mode == "stub_tools"
+    assert stub.guide_id is None
+
+    resp = run_assistant_turn(ChatRequest(message=_FREEFORM, audience=Audience.PUBLIC))
+    assert resp.mode == "stub_tools"
+    assert "asistente" in resp.reply.lower() or "depósito" in resp.reply.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_hybrid_uses_llm_on_fallback(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ASSISTANT_LLM", "1")
+    monkeypatch.setenv("GROK_API_KEY", "xai-test-key")
+
+    def fake_llm(**_kwargs: Any):
+        return (
+            "Para un closet empotrado te conviene listones, tornillos y correderas.",
+            ["catalog.search_products"],
+            [{"tool": "catalog.search_products", "result": {"products": []}}],
+        )
+
+    monkeypatch.setattr(llm_router, "run_llm_turn", fake_llm)
+
+    resp = run_assistant_turn(ChatRequest(message=_FREEFORM, audience=Audience.PUBLIC))
+    assert resp.mode == "llm_tools"
+    assert "closet" in resp.reply.lower() or "listones" in resp.reply.lower()
+    assert "catalog.search_products" in resp.tools_used
+    assert "SKU" not in resp.reply
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_llm_failure_falls_back_to_stub_help(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ASSISTANT_LLM", "1")
+    monkeypatch.setenv("GROK_API_KEY", "xai-test-key")
+    monkeypatch.setattr(llm_router, "run_llm_turn", lambda **_k: None)
+
+    resp = run_assistant_turn(ChatRequest(message=_FREEFORM, audience=Audience.PUBLIC))
+    assert resp.mode == "stub_tools"
+    assert resp.llm_eligible is True  # stub help still marked; API does not care
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_tools_for_llm_allowlist_only():
+    from depotru_tools.registry import get_default_registry
+
+    tools = llm_router.tools_for_llm(get_default_registry(), Audience.PUBLIC)
+    names = {t["function"]["name"] for t in tools}
+    assert "info.branches" in names
+    assert "catalog.search_products" in names
+    assert "platform.health" not in names
+    assert "catalog.related_for_sku" not in names
+    assert "inventory.sellable_qty" not in names
+    assert "attribution.resolve_seller" not in names
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_execute_blocks_non_allowlisted_tool():
+    from depotru_tools.registry import ToolContext, get_default_registry
+
+    reg = get_default_registry()
+    ctx = ToolContext(audience=Audience.PUBLIC)
+    result, err = llm_router._execute_tool(
+        reg, ctx, "attribution.resolve_seller", {"code": "095"}
+    )
+    assert result is None
+    assert err is not None
+    assert "not allowed" in err.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_sanitize_strips_sku_lines():
+    text = "Te recomiendo:\n• Pintura vinilo\nSKU: 002001\n• Rodillo"
+    out = llm_router.sanitize_customer_reply(text)
+    assert "002001" not in out
+    assert "Pintura" in out
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_run_llm_turn_mocked_openai(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("ASSISTANT_LLM", "1")
+    monkeypatch.setenv("GROK_API_KEY", "xai-test-key")
+
+    # Message with no tool_calls → direct text
+    mock_msg = SimpleNamespace(
+        content="Hola, soy el asistente de la tienda.", tool_calls=None
+    )
+    mock_choice = SimpleNamespace(message=mock_msg)
+    mock_resp = SimpleNamespace(choices=[mock_choice])
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_resp
+
+    mock_openai_cls = MagicMock(return_value=mock_client)
+    mock_mod = MagicMock()
+    mock_mod.OpenAI = mock_openai_cls
+    monkeypatch.setitem(__import__("sys").modules, "openai", mock_mod)
+
+    from depotru_tools.registry import get_default_registry
+
+    out = llm_router.run_llm_turn(
+        message="ayuda genérica sin match",
+        session_id="s1",
+        audience=Audience.PUBLIC,
+        registry=get_default_registry(),
+    )
+    assert out is not None
+    reply, tools_used, _ = out
+    assert "asistente" in reply.lower()
+    assert tools_used == []
+    mock_client.chat.completions.create.assert_called()

--- a/tests/platform/test_tools_and_assistant.py
+++ b/tests/platform/test_tools_and_assistant.py
@@ -60,11 +60,19 @@ def test_assistant_branches_turn():
     resp = run_assistant_turn(
         ChatRequest(message="¿dónde están las sedes?", audience=Audience.PUBLIC)
     )
-    assert "Sede Principal" in resp.reply
+    assert "Bodega del Sur" in resp.reply
+    assert "Bodega Mangueras" in resp.reply
+    assert "Bodega 6" in resp.reply
+    assert "Distribuciones" in resp.reply or "Calle 5" in resp.reply
+    assert "Dirección:" in resp.reply
+    assert "Calle 24" in resp.reply or "Carrera 20" in resp.reply
+    assert "depositotrujillo.co/bodegas" in resp.reply
     assert "info.branches" in resp.tools_used
     assert resp.grounded is True
     # No internal ERP branch codes for customers
     assert "FED" not in resp.reply
+    assert "FEF" not in resp.reply
+    assert "FET" not in resp.reply
 
 
 @pytest.mark.unit
@@ -73,8 +81,20 @@ def test_assistant_branches_cuales_son_las_sedes():
     resp = run_assistant_turn(
         ChatRequest(message="cuales son las sedes", audience=Audience.PUBLIC)
     )
-    assert "Sede Principal" in resp.reply or "sedes" in resp.reply.lower()
+    assert "Bodega" in resp.reply or "sedes" in resp.reply.lower()
+    assert "Dirección:" in resp.reply
     assert "info.branches" in resp.tools_used
+
+
+@pytest.mark.unit
+@pytest.mark.module_assistant
+def test_assistant_bodegas_keyword_routes():
+    resp = run_assistant_turn(
+        ChatRequest(message="dónde quedan las bodegas", audience=Audience.PUBLIC)
+    )
+    assert "info.branches" in resp.tools_used
+    assert "Bodega del Sur" in resp.reply
+    assert "Horario:" in resp.reply
 
 
 @pytest.mark.unit
@@ -215,7 +235,8 @@ def test_assistant_sede_quede_principal():
         ChatRequest(message="Dónde quede la sede principal", audience=Audience.PUBLIC)
     )
     assert "info.branches" in resp.tools_used
-    assert "Sede Principal" in resp.reply or "sedes" in resp.reply.lower()
+    assert "Dirección:" in resp.reply
+    assert "Bodega" in resp.reply or "Distribuciones" in resp.reply
 
 
 @pytest.mark.unit
@@ -309,8 +330,10 @@ def test_v1_api_tools_and_chat(monkeypatch: pytest.MonkeyPatch):
     )
     assert r3.status_code == 200
     body = r3.json()
-    assert "FED" in body["reply"] or "sedes" in body["reply"].lower()
+    assert "Bodega" in body["reply"] or "sedes" in body["reply"].lower()
+    assert "Dirección:" in body["reply"] or "bodegas" in body["reply"].lower()
     assert body["grounded"] is True
+    assert "FED" not in body["reply"]
     # Response schema includes optional routing diagnostics
     assert "guide_id" in body
     assert "product_query" in body


### PR DESCRIPTION
## Summary
- Hybrid routing: deterministic stub first; LLM only when stub would return generic help
- New `modules.assistant.llm_router` (Grok/xAI, allowlisted public tools only)
- `mode=llm_tools` when LLM answers; fail-soft back to stub help
- Enable with `ASSISTANT_LLM=1` + `GROK_API_KEY` (default off for CI)

## Test plan
- [x] `pytest tests/platform/ -q` (40 passed)
- [ ] Set `ASSISTANT_LLM=1` on BFF and smoke free-form vs «hola» / gotera
- [ ] CI green

## Out of scope
- Named tunnel, Magento sellable qty token, CRM