### PR TITLE
feat(cartera): AR aging HTML/PDF report from banco_cartera

### DIFF
--- a/reports/README.md
+++ b/reports/README.md
@@ -8,6 +8,7 @@ This directory contains generated analysis reports and their supporting data.
 - `DATABASE_TABLE_DECISION_SUMMARY.md` - Live inventory of every SmartBusiness + J3System table with decision-oriented explanations (refresh via `scripts/utils/introspect_table_sizes.py`)
 - `DATABASE_TABLE_ANALYSIS_RECOMMENDATIONS.md` - Strategic recommendations companion (2026-07-07 baseline)
 - `ROTACION_EXISTENCIAS_<date>.html` (also `.pdf` / `.md` via CLI) - Commercial warehouse inventory turnover (quiebre, muerto, transfers); CLI or **Vanna UI → Informes recomendados** at `http://127.0.0.1:8084/`
+- `CARTERA_AGING_<date>.html` (also `.pdf` / `.md` / `.json` via CLI) - AR aging from `banco_cartera` (mora, buckets, top vencidos, cupos); CLI `scripts/analysis/run_cartera_aging.py` or **Informes recomendados → Cartera / Aging**
 - `CRITICAL_INVENTORY_<date>.md` - Risk shortlist (Q13); commercial WH + warehouse demand
 - `ANALYSIS_REPORT.md` - Comprehensive analysis across all categories
 - `KPI_CONTROL_BOARD_TEMPLATE.md` - Weekly KPI operating template (scorecard + actions)

--- a/scripts/analysis/run_cartera_aging.py
+++ b/scripts/analysis/run_cartera_aging.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""CLI: Cartera / AR aging (banco_cartera snapshot report)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+_REPO = Path(__file__).resolve().parents[2]
+_SRC = _REPO / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from business_analyzer.reports.cartera_aging import (  # noqa: E402
+    build_cartera_result,
+    default_as_of_date,
+)
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=(
+            "Cartera / Aging: cuentas por cobrar, mora, concentración y cupos "
+            "(SmartBusiness banco_cartera, último snapshot fecha_carga)"
+        )
+    )
+    p.add_argument(
+        "--as-of-date",
+        default=default_as_of_date(),
+        help="Reference date YYYY-MM-DD (default: yesterday)",
+    )
+    p.add_argument(
+        "--top-n",
+        type=int,
+        default=25,
+        help="Max rows per action table (default: 25)",
+    )
+    p.add_argument(
+        "--dso-days",
+        type=int,
+        default=30,
+        help="Sales window in days for DSO (default: 30)",
+    )
+    p.add_argument(
+        "--no-dso",
+        action="store_true",
+        help="Skip DSO / banco_datos sales query",
+    )
+    p.add_argument(
+        "--output",
+        default="",
+        help="Output path (default: reports/CARTERA_AGING_<date>.html)",
+    )
+    p.add_argument(
+        "--format",
+        choices=("html", "pdf", "markdown", "json"),
+        default="html",
+        help="Output format (default: html)",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="Also write sibling .json",
+    )
+    p.add_argument(
+        "--json-only",
+        action="store_true",
+        help="Print report JSON to stdout only (still hits DB)",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+
+    if args.output:
+        out = Path(args.output).resolve()
+        output_dir = out.parent
+        custom_name = out.name
+    else:
+        output_dir = _REPO / "reports"
+        custom_name = None
+
+    if args.json_only:
+        from business_analyzer.core.cartera_aging import CarteraAgingRunner
+        from business_analyzer.core.database import Database
+
+        runner = CarteraAgingRunner(
+            Database(),
+            top_n=args.top_n,
+            dso_days=args.dso_days,
+            include_dso=not args.no_dso,
+        )
+        report = runner.build_report(args.as_of_date)
+        print(json.dumps(report, indent=2, default=str))
+        return 0
+
+    result = build_cartera_result(
+        as_of_date=args.as_of_date,
+        top_n=args.top_n,
+        dso_days=args.dso_days,
+        include_dso=not args.no_dso,
+        output_dir=output_dir,
+        write_json=args.json,
+        fmt=args.format,
+    )
+    if result.get("status") == "error":
+        print(f"❌ {result.get('message')}", file=sys.stderr)
+        return 1
+
+    written = Path(result["path"])
+    if custom_name and written.name != custom_name:
+        target = output_dir / custom_name
+        written.rename(target)
+        if args.json:
+            jsrc = written.with_suffix(".json")
+            if jsrc.is_file():
+                jsrc.rename(target.with_suffix(".json"))
+        written = target
+        result["path"] = str(written)
+
+    print(f"✅ Cartera aging: {written}")
+    if args.json:
+        print(f"✅ JSON: {written.with_suffix('.json')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/business_analyzer/ai/flask_app.py
+++ b/src/business_analyzer/ai/flask_app.py
@@ -155,6 +155,34 @@ def rotacion_api_payload(result: Dict[str, Any], cache_id: str) -> Dict[str, Any
     }
 
 
+def cartera_status_text(result: Dict[str, Any]) -> str:
+    as_of = result.get("as_of_date")
+    filename = Path(result["path"]).name if result.get("path") else None
+    if filename:
+        return f"✓ Cartera / aging lista — {as_of} ({filename})"
+    return f"✓ Cartera / aging — {as_of}"
+
+
+def cartera_api_payload(result: Dict[str, Any], cache_id: str) -> Dict[str, Any]:
+    status = result.get("status")
+    if status == "error":
+        return {
+            "type": "error",
+            "id": cache_id,
+            "error": result.get("message", "Error generando cartera / aging"),
+        }
+    return {
+        "type": "cartera",
+        "id": cache_id,
+        "text": result.get("message", ""),
+        "status_text": cartera_status_text(result),
+        "download_url": manager_report_download_path(result.get("path")),
+        "format": result.get("format", "html"),
+        "as_of_date": result.get("as_of_date"),
+        "insights_count": result.get("insights_count"),
+    }
+
+
 def manager_report_api_payload(result: Dict[str, Any], cache_id: str) -> Dict[str, Any]:
     """Serialize a manager report routing result for the Vanna web UI."""
     status = result.get("status")
@@ -485,6 +513,66 @@ class SmartVannaFlaskApp(VannaFlaskApp):
             cache.set(id=cache_id, field="rotacion", value=result)
             return jsonify(rotacion_api_payload(result, cache_id))
 
+        @requires_auth
+        def generate_cartera(user):
+            as_of_date = flask.request.args.get("as_of_date")
+            top_n = flask.request.args.get("top_n", type=int)
+            fmt = flask.request.args.get("format", "html")
+            dso_days = flask.request.args.get("dso_days", type=int)
+
+            if flask.request.method == "POST":
+                body = flask.request.get_json(silent=True) or {}
+                as_of_date = body.get("as_of_date", as_of_date)
+                top_n = body.get("top_n", top_n)
+                fmt = body.get("format", fmt)
+                dso_days = body.get("dso_days", dso_days)
+
+            if not as_of_date:
+                return jsonify(
+                    {
+                        "type": "error",
+                        "error": "Indica as_of_date (YYYY-MM-DD) para cartera.",
+                    }
+                )
+
+            top_n = int(top_n) if top_n is not None else 25
+            dso_days = int(dso_days) if dso_days is not None else 30
+            fmt = str(fmt or "html").strip().lower()
+            cache_id = cache.generate_id(
+                as_of_date=as_of_date,
+                top_n=top_n,
+                dso_days=dso_days,
+                format=fmt,
+                report="cartera",
+            )
+
+            try:
+                from business_analyzer.reports.cartera_aging import build_cartera_result
+
+                result = build_cartera_result(
+                    as_of_date=str(as_of_date),
+                    top_n=top_n,
+                    dso_days=dso_days,
+                    fmt=fmt,
+                )
+            except Exception:
+                logging.getLogger(__name__).exception(
+                    "generate_cartera failed as_of=%s fmt=%s", as_of_date, fmt
+                )
+                result = {
+                    "status": "error",
+                    "message": (
+                        "Error generando cartera / aging. "
+                        "Revise la fecha/formato o los logs del servidor."
+                    ),
+                }
+
+            if result.get("status") == "error":
+                return jsonify(cartera_api_payload(result, cache_id))
+
+            cache.set(id=cache_id, field="cartera", value=result)
+            return jsonify(cartera_api_payload(result, cache_id))
+
         @self.flask_app.route("/api/v0/recommended_reports", methods=["GET"])
         def recommended_reports():
             return jsonify(recommended_reports_payload())
@@ -519,6 +607,12 @@ class SmartVannaFlaskApp(VannaFlaskApp):
             "/api/v0/generate_rotacion",
             endpoint="smart_generate_rotacion",
             view_func=generate_rotacion,
+            methods=["GET", "POST"],
+        )
+        self.flask_app.add_url_rule(
+            "/api/v0/generate_cartera",
+            endpoint="smart_generate_cartera",
+            view_func=generate_cartera,
             methods=["GET", "POST"],
         )
         self._patch_assets_js()

--- a/src/business_analyzer/ai/recommended_reports.py
+++ b/src/business_analyzer/ai/recommended_reports.py
@@ -131,6 +131,16 @@ def get_recommended_report_templates() -> List[Dict[str, Any]]:
             "period_type": "as_of_date",
             "template": {"report_kind": "rotacion_existencias"},
         },
+        {
+            "id": "cartera-aging",
+            "title": "Cartera / Aging",
+            "description": (
+                "HTML/PDF: cartera total, mora por buckets, top vencidos, "
+                "concentración, sobre cupo y plan de cobranza 7 días."
+            ),
+            "period_type": "as_of_date",
+            "template": {"report_kind": "cartera_aging"},
+        },
     ]
 
 
@@ -154,11 +164,16 @@ def get_recommended_reports(*, today: Optional[date] = None) -> List[Dict[str, A
             )
             continue
         if entry.get("period_type") == "as_of_date":
+            kind = (entry.get("template") or {}).get("report_kind")
+            if kind == "cartera_aging":
+                action_type = "generate_cartera"
+            else:
+                action_type = "generate_rotacion"
             reports.append(
                 {
                     **entry,
                     "action": {
-                        "type": "generate_rotacion",
+                        "type": action_type,
                         "as_of_date": as_of,
                     },
                 }
@@ -351,7 +366,7 @@ body.informes-layout #app {
 RECOMMENDED_REPORTS_PANEL_HTML = """
 <aside id="informes-recomendados" class="informes-recomendados" aria-label="Informes recomendados">
   <h2>Informes recomendados</h2>
-  <p class="informes-subtitle">Informes mensuales, KPI semanal o rotación de existencias (fecha).</p>
+  <p class="informes-subtitle">Informes mensuales, KPI semanal, rotación o cartera (fecha).</p>
   <div id="informes-recomendados-list" class="informes-recomendados-list" role="list"></div>
   <p id="informes-recomendados-status" class="informes-recomendados-status" aria-live="polite"></p>
 </aside>
@@ -432,11 +447,24 @@ RECOMMENDED_REPORTS_JS = """
     return response.json();
   }
 
+  async function triggerCartera(asOfDate, fmt) {
+    const response = await fetch("/api/v0/generate_cartera", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        as_of_date: asOfDate,
+        format: fmt || "html",
+      }),
+    });
+    return response.json();
+  }
+
   function handleGenerateResult(result) {
     if (
       result.type === "manager_report" ||
       result.type === "kpi_board" ||
-      result.type === "rotacion"
+      result.type === "rotacion" ||
+      result.type === "cartera"
     ) {
       setStatus(shortStatus(result), false);
       if (result.download_url) window.open(result.download_url, "_blank");
@@ -459,6 +487,13 @@ RECOMMENDED_REPORTS_JS = """
     card.setAttribute("role", "listitem");
     card.dataset.reportId = report.id;
 
+    const kind =
+      (report.template && report.template.report_kind) ||
+      (report.action && report.action.type === "generate_cartera"
+        ? "cartera_aging"
+        : "rotacion_existencias");
+    const isCartera = kind === "cartera_aging";
+
     const title = document.createElement("span");
     title.className = "informe-card-title";
     title.textContent = report.title;
@@ -478,7 +513,10 @@ RECOMMENDED_REPORTS_JS = """
 
     const formatSelect = document.createElement("select");
     formatSelect.className = "informe-format";
-    formatSelect.setAttribute("aria-label", "Formato del informe de rotación");
+    formatSelect.setAttribute(
+      "aria-label",
+      isCartera ? "Formato del informe de cartera" : "Formato del informe de rotación"
+    );
     [
       { value: "html", label: "HTML" },
       { value: "pdf", label: "PDF" },
@@ -493,7 +531,7 @@ RECOMMENDED_REPORTS_JS = """
     const generateBtn = document.createElement("button");
     generateBtn.type = "button";
     generateBtn.className = "informe-generate-btn";
-    generateBtn.textContent = "Generar rotación";
+    generateBtn.textContent = isCartera ? "Generar cartera" : "Generar rotación";
 
     period.appendChild(dateInput);
     period.appendChild(formatSelect);
@@ -513,9 +551,16 @@ RECOMMENDED_REPORTS_JS = """
       const fmt = formatSelect.value || "html";
       card.classList.add("is-busy");
       generateBtn.disabled = true;
-      setStatus("Generando rotación de existencias (" + fmt.toUpperCase() + ")…", false);
+      setStatus(
+        isCartera
+          ? "Generando cartera / aging (" + fmt.toUpperCase() + ")…"
+          : "Generando rotación de existencias (" + fmt.toUpperCase() + ")…",
+        false
+      );
       try {
-        const result = await triggerRotacion(asOf, fmt);
+        const result = isCartera
+          ? await triggerCartera(asOf, fmt)
+          : await triggerRotacion(asOf, fmt);
         handleGenerateResult(result);
       } catch (err) {
         setStatus("No se pudo contactar el servidor.", true);

--- a/src/business_analyzer/core/cartera_aging.py
+++ b/src/business_analyzer/core/cartera_aging.py
@@ -1,0 +1,525 @@
+"""Cartera / AR aging analytics from SmartBusiness ``banco_cartera``.
+
+Uses the latest ``fecha_carga`` snapshot only (v1). Optional ``as_of_date``
+selects the newest snapshot on or before that calendar day. KPI math aligns
+with Q9 in ``kpi_sql_pack.sql.template``. Optional DSO uses ``banco_datos``
+with the canonical sales document exclusions.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date, timedelta
+from typing import Any, Dict, List, Mapping, Optional, Sequence, cast
+
+from business_analyzer.core.database import Database, qualified_sb_table
+from depotru_kernel.documents import (
+    CANONICAL_EXCLUDED_DOCUMENT_CODES,
+    excluded_document_sql_in_list,
+)
+
+DEFAULT_TOP_N = 25
+DEFAULT_DSO_DAYS = 30
+
+# Columns allowed in SELECT (decision summary / Q9 family).
+SNAPSHOT_SELECT_COLUMNS: tuple[str, ...] = (
+    "cliente_uid",
+    "cliente_nit",
+    "cliente_razon_social",
+    "cliente_ciudad",
+    "cliente_departamento",
+    "vendedor_nombre",
+    "corriente",
+    "vencido",
+    "vencido_30",
+    "vencido_60",
+    "vencido_90",
+    "vencido_120",
+    "vencido_360",
+    "vencido_superior",
+    "total",
+    "dias_vencidos",
+    "cliente_cupo",
+    "fecha_carga",
+)
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+BUCKET_KEYS: tuple[tuple[str, str], ...] = (
+    ("corriente", "Corriente (al día)"),
+    ("vencido_30", "Vencido 1–30 d"),
+    ("vencido_60", "Vencido 31–60 d"),
+    ("vencido_90", "Vencido 61–90 d"),
+    ("vencido_120", "Vencido 91–120 d"),
+    ("vencido_360", "Vencido 121–360 d"),
+    ("vencido_superior", "Vencido >360 d"),
+)
+
+
+def _as_float(value: Any) -> float:
+    try:
+        if value is None:
+            return 0.0
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _as_int(value: Any) -> int:
+    try:
+        if value is None:
+            return 0
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def validate_as_of_date(as_of_date: str) -> str:
+    raw = (as_of_date or "").strip()
+    if not _DATE_RE.fullmatch(raw):
+        raise ValueError(f"Invalid as_of_date (use YYYY-MM-DD): {as_of_date!r}")
+    date.fromisoformat(raw)
+    return raw
+
+
+def default_as_of_date(*, today: Optional[date] = None) -> str:
+    """Default as-of date: yesterday."""
+    ref = today or date.today()
+    return (ref - timedelta(days=1)).isoformat()
+
+
+def safe_divide(n: float, d: float, default: float = 0.0) -> float:
+    return n / d if d != 0 else default
+
+
+def build_snapshot_sql(
+    *,
+    as_of_date: Optional[str] = None,
+    sb_database: Optional[str] = None,
+) -> str:
+    """SQL for open AR rows on the latest ``fecha_carga`` snapshot.
+
+    When ``as_of_date`` is set, picks the newest snapshot on or before that day.
+    """
+    table = qualified_sb_table("banco_cartera", sb_database)
+    cols = ",\n        ".join(SNAPSHOT_SELECT_COLUMNS)
+    if as_of_date:
+        as_of = validate_as_of_date(as_of_date)
+        snapshot_filter = (
+            f"fecha_carga = ("
+            f"SELECT MAX(fecha_carga) FROM {table} "
+            f"WHERE CAST(fecha_carga AS DATE) <= CAST('{as_of}' AS DATE)"
+            f")"
+        )
+    else:
+        snapshot_filter = f"fecha_carga = (SELECT MAX(fecha_carga) FROM {table})"
+    return f"""
+SELECT
+        {cols}
+FROM {table}
+WHERE {snapshot_filter}
+""".strip()
+
+
+def build_dso_sales_sql(
+    *,
+    as_of_date: str,
+    dso_days: int = DEFAULT_DSO_DAYS,
+    sb_database: Optional[str] = None,
+) -> str:
+    """Net sales (sin IVA) for DSO denominator over ``dso_days`` ending on as_of."""
+    as_of = validate_as_of_date(as_of_date)
+    days = int(dso_days)
+    if days <= 0:
+        raise ValueError("dso_days must be positive")
+    banco = qualified_sb_table("banco_datos", sb_database)
+    excluded = excluded_document_sql_in_list()
+    return f"""
+SELECT
+    SUM(TotalSinIva) AS ventas_netas,
+    {days} AS dias_periodo
+FROM {banco}
+WHERE DocumentosCodigo NOT IN ({excluded})
+  AND Fecha >= DATEADD(DAY, -{days - 1}, CAST('{as_of}' AS DATE))
+  AND Fecha <= CAST('{as_of}' AS DATE)
+""".strip()
+
+
+def aggregate_clients(
+    rows: Sequence[Mapping[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Roll document-level snapshot rows up to one row per customer."""
+    buckets: Dict[str, Dict[str, Any]] = {}
+    for raw in rows:
+        uid = raw.get("cliente_uid")
+        nit = str(raw.get("cliente_nit") or "").strip()
+        name = str(raw.get("cliente_razon_social") or "").strip()
+        if uid is not None:
+            key = f"uid:{uid}"
+        elif nit:
+            key = f"nit:{nit}"
+        elif name:
+            key = f"name:{name}"
+        else:
+            key = f"row:{id(raw)}"
+        b = buckets.get(key)
+        if b is None:
+            b = {
+                "cliente_uid": uid,
+                "cliente_nit": nit,
+                "cliente_razon_social": name,
+                "cliente_ciudad": raw.get("cliente_ciudad"),
+                "cliente_departamento": raw.get("cliente_departamento"),
+                "vendedor_nombre": raw.get("vendedor_nombre"),
+                "cliente_cupo": _as_float(raw.get("cliente_cupo")),
+                "corriente": 0.0,
+                "vencido": 0.0,
+                "vencido_30": 0.0,
+                "vencido_60": 0.0,
+                "vencido_90": 0.0,
+                "vencido_120": 0.0,
+                "vencido_360": 0.0,
+                "vencido_superior": 0.0,
+                "total": 0.0,
+                "dias_vencidos": 0,
+                "documentos": 0,
+            }
+            buckets[key] = b
+        for money_key in (
+            "corriente",
+            "vencido",
+            "vencido_30",
+            "vencido_60",
+            "vencido_90",
+            "vencido_120",
+            "vencido_360",
+            "vencido_superior",
+            "total",
+        ):
+            b[money_key] = _as_float(b[money_key]) + _as_float(raw.get(money_key))
+        cupo = _as_float(raw.get("cliente_cupo"))
+        if cupo > _as_float(b.get("cliente_cupo")):
+            b["cliente_cupo"] = cupo
+        dias = _as_int(raw.get("dias_vencidos"))
+        if dias > _as_int(b.get("dias_vencidos")):
+            b["dias_vencidos"] = dias
+        if raw.get("vendedor_nombre") and not b.get("vendedor_nombre"):
+            b["vendedor_nombre"] = raw.get("vendedor_nombre")
+        if raw.get("cliente_ciudad") and not b.get("cliente_ciudad"):
+            b["cliente_ciudad"] = raw.get("cliente_ciudad")
+        b["documentos"] = _as_int(b.get("documentos")) + 1
+
+    clients = list(buckets.values())
+    for c in clients:
+        cupo = _as_float(c.get("cliente_cupo"))
+        total = _as_float(c.get("total"))
+        c["sobre_cupo"] = bool(cupo > 0 and total > cupo)
+        c["exceso_cupo"] = max(total - cupo, 0.0) if cupo > 0 else 0.0
+        c["vencido_90_plus"] = (
+            _as_float(c.get("vencido_90"))
+            + _as_float(c.get("vencido_120"))
+            + _as_float(c.get("vencido_360"))
+            + _as_float(c.get("vencido_superior"))
+        )
+        c["share_total"] = 0.0  # filled after totals known
+    return clients
+
+
+def compute_summary(
+    clients: Sequence[Mapping[str, Any]],
+    *,
+    document_row_count: int = 0,
+    dso_dias: Optional[float] = None,
+    ventas_netas: Optional[float] = None,
+    dias_periodo: int = DEFAULT_DSO_DAYS,
+    fecha_carga: Any = None,
+) -> Dict[str, Any]:
+    """Portfolio KPIs aligned with Q9 (client-aggregated where sensible)."""
+    cartera_total = sum(_as_float(c.get("total")) for c in clients)
+    corriente = sum(_as_float(c.get("corriente")) for c in clients)
+    vencido = sum(_as_float(c.get("vencido")) for c in clients)
+    v30 = sum(_as_float(c.get("vencido_30")) for c in clients)
+    v60 = sum(_as_float(c.get("vencido_60")) for c in clients)
+    v90 = sum(_as_float(c.get("vencido_90")) for c in clients)
+    v120 = sum(_as_float(c.get("vencido_120")) for c in clients)
+    v360 = sum(_as_float(c.get("vencido_360")) for c in clients)
+    vsup = sum(_as_float(c.get("vencido_superior")) for c in clients)
+    vencido_90_plus = v90 + v120 + v360 + vsup
+
+    weighted_days = 0.0
+    for c in clients:
+        total = _as_float(c.get("total"))
+        dias = max(_as_int(c.get("dias_vencidos")), 0)
+        weighted_days += total * dias
+    dias_prom = safe_divide(weighted_days, cartera_total, 0.0)
+
+    sobre = sum(1 for c in clients if c.get("sobre_cupo"))
+    con_saldo = sum(1 for c in clients if abs(_as_float(c.get("total"))) > 0.005)
+
+    return {
+        "Cartera_Total": cartera_total,
+        "Cartera_Corriente": corriente,
+        "Cartera_Vencida": vencido,
+        "Cartera_Vencida_Pct": safe_divide(vencido * 100.0, cartera_total),
+        "Cartera_Vencida_90_Plus": vencido_90_plus,
+        "Cartera_Vencida_90_Plus_Pct": safe_divide(
+            vencido_90_plus * 100.0, cartera_total
+        ),
+        "Clientes_Con_Saldo": con_saldo,
+        "Clientes_Sobre_Cupo": sobre,
+        "Documentos_Filas": int(document_row_count),
+        "Dias_Vencidos_Promedio_Ponderado": dias_prom,
+        "DSO_Dias": dso_dias,
+        "Ventas_Netas_Periodo": ventas_netas,
+        "Dias_Periodo": int(dias_periodo),
+        "Fecha_Carga_Cartera": fecha_carga,
+        "Bucket_Corriente": corriente,
+        "Bucket_Vencido_30": v30,
+        "Bucket_Vencido_60": v60,
+        "Bucket_Vencido_90": v90,
+        "Bucket_Vencido_120": v120,
+        "Bucket_Vencido_360": v360,
+        "Bucket_Vencido_Superior": vsup,
+    }
+
+
+def bucket_breakdown(
+    summary: Mapping[str, Any],
+) -> List[Dict[str, Any]]:
+    """Aging bucket amounts + share of total AR."""
+    total = _as_float(summary.get("Cartera_Total"))
+    mapping = {
+        "corriente": summary.get("Bucket_Corriente"),
+        "vencido_30": summary.get("Bucket_Vencido_30"),
+        "vencido_60": summary.get("Bucket_Vencido_60"),
+        "vencido_90": summary.get("Bucket_Vencido_90"),
+        "vencido_120": summary.get("Bucket_Vencido_120"),
+        "vencido_360": summary.get("Bucket_Vencido_360"),
+        "vencido_superior": summary.get("Bucket_Vencido_Superior"),
+    }
+    out: List[Dict[str, Any]] = []
+    for key, label in BUCKET_KEYS:
+        amount = _as_float(mapping.get(key))
+        out.append(
+            {
+                "bucket": key,
+                "label": label,
+                "amount": amount,
+                "share_pct": safe_divide(amount * 100.0, total),
+            }
+        )
+    return out
+
+
+def top_overdue(
+    clients: Sequence[Mapping[str, Any]],
+    *,
+    top_n: int = DEFAULT_TOP_N,
+) -> List[Dict[str, Any]]:
+    """Clients ranked by overdue balance (then days overdue)."""
+    filtered = [
+        dict(c)
+        for c in clients
+        if _as_float(c.get("vencido")) > 0 or _as_int(c.get("dias_vencidos")) > 0
+    ]
+    filtered.sort(
+        key=lambda c: (
+            -_as_float(c.get("vencido")),
+            -_as_int(c.get("dias_vencidos")),
+            -_as_float(c.get("total")),
+        )
+    )
+    return filtered[: max(0, int(top_n))]
+
+
+def top_concentration(
+    clients: Sequence[Mapping[str, Any]],
+    *,
+    top_n: int = DEFAULT_TOP_N,
+) -> List[Dict[str, Any]]:
+    """Largest AR balances with cumulative share (concentration)."""
+    ranked = sorted(
+        (dict(c) for c in clients if abs(_as_float(c.get("total"))) > 0.005),
+        key=lambda c: -_as_float(c.get("total")),
+    )
+    total = sum(_as_float(c.get("total")) for c in ranked) or 1.0
+    cum = 0.0
+    out: List[Dict[str, Any]] = []
+    for c in ranked[: max(0, int(top_n))]:
+        amt = _as_float(c.get("total"))
+        cum += amt
+        row = dict(c)
+        row["share_total"] = safe_divide(amt, total)
+        row["share_acum"] = safe_divide(cum, total)
+        out.append(row)
+    return out
+
+
+def over_limit_clients(
+    clients: Sequence[Mapping[str, Any]],
+    *,
+    top_n: int = DEFAULT_TOP_N,
+) -> List[Dict[str, Any]]:
+    """Clients with total AR above credit limit."""
+    filtered = [dict(c) for c in clients if c.get("sobre_cupo")]
+    filtered.sort(key=lambda c: -_as_float(c.get("exceso_cupo")))
+    return filtered[: max(0, int(top_n))]
+
+
+def by_vendedor(
+    clients: Sequence[Mapping[str, Any]],
+    *,
+    top_n: int = 15,
+) -> List[Dict[str, Any]]:
+    """AR and overdue totals by seller name."""
+    buckets: Dict[str, Dict[str, Any]] = {}
+    for c in clients:
+        name = (
+            str(c.get("vendedor_nombre") or "(sin vendedor)").strip()
+            or "(sin vendedor)"
+        )
+        b = buckets.setdefault(
+            name,
+            {
+                "vendedor_nombre": name,
+                "clientes": 0,
+                "total": 0.0,
+                "vencido": 0.0,
+                "vencido_90_plus": 0.0,
+            },
+        )
+        b["clientes"] += 1
+        b["total"] = _as_float(b["total"]) + _as_float(c.get("total"))
+        b["vencido"] = _as_float(b["vencido"]) + _as_float(c.get("vencido"))
+        b["vencido_90_plus"] = _as_float(b["vencido_90_plus"]) + _as_float(
+            c.get("vencido_90_plus")
+        )
+    ranked = sorted(buckets.values(), key=lambda x: -_as_float(x.get("total")))
+    return ranked[: max(0, int(top_n))]
+
+
+def compute_dso(cartera_total: float, ventas_netas: float, dias_periodo: int) -> float:
+    """DSO = Cartera / (ventas_netas / días) = cartera * días / ventas."""
+    if ventas_netas is None or ventas_netas == 0 or dias_periodo <= 0:
+        return 0.0
+    return (cartera_total * float(dias_periodo)) / float(ventas_netas)
+
+
+def build_report_from_rows(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    as_of_date: str,
+    top_n: int = DEFAULT_TOP_N,
+    dso_days: int = DEFAULT_DSO_DAYS,
+    ventas_netas: Optional[float] = None,
+    include_dso: bool = True,
+) -> Dict[str, Any]:
+    """Pure builder: assemble full report dict from snapshot rows (+ optional sales)."""
+    as_of = validate_as_of_date(as_of_date)
+    clients = aggregate_clients(rows)
+    fecha_carga = None
+    if rows:
+        fecha_carga = rows[0].get("fecha_carga")
+        for r in rows:
+            fc = r.get("fecha_carga")
+            if fc is not None and (fecha_carga is None or str(fc) > str(fecha_carga)):
+                fecha_carga = fc
+
+    dso_val: Optional[float] = None
+    ventas = ventas_netas
+    if include_dso and ventas is not None:
+        dso_val = compute_dso(
+            sum(_as_float(c.get("total")) for c in clients),
+            float(ventas),
+            int(dso_days),
+        )
+
+    summary = compute_summary(
+        clients,
+        document_row_count=len(rows),
+        dso_dias=dso_val,
+        ventas_netas=ventas,
+        dias_periodo=int(dso_days),
+        fecha_carga=fecha_carga,
+    )
+    # Fill share on all clients for consumers
+    total_ar = _as_float(summary.get("Cartera_Total")) or 1.0
+    for c in clients:
+        c["share_total"] = safe_divide(_as_float(c.get("total")), total_ar)
+
+    return {
+        "as_of_date": as_of,
+        "fecha_carga_snapshot": fecha_carga,
+        "source": "banco_cartera",
+        "dso_days_window": int(dso_days),
+        "include_dso": bool(include_dso),
+        "excluded_document_codes": list(CANONICAL_EXCLUDED_DOCUMENT_CODES),
+        "summary": summary,
+        "buckets": bucket_breakdown(summary),
+        "top_overdue": top_overdue(clients, top_n=top_n),
+        "top_concentration": top_concentration(clients, top_n=top_n),
+        "over_limit": over_limit_clients(clients, top_n=top_n),
+        "by_vendedor": by_vendedor(clients),
+        "client_count": len(clients),
+        "document_row_count": len(rows),
+    }
+
+
+class CarteraAgingRunner:
+    """Fetch latest AR snapshot and assemble the aging report."""
+
+    def __init__(
+        self,
+        db: Optional[Database] = None,
+        *,
+        sb_database: Optional[str] = None,
+        top_n: int = DEFAULT_TOP_N,
+        dso_days: int = DEFAULT_DSO_DAYS,
+        include_dso: bool = True,
+    ) -> None:
+        self.db = db or Database()
+        self.sb_database = sb_database
+        self.top_n = int(top_n)
+        self.dso_days = int(dso_days)
+        self.include_dso = bool(include_dso)
+
+    def _execute_query(self, sql: str) -> List[Dict[str, Any]]:
+        self.db.connect()
+        rows = cast(List[Dict[str, Any]], self.db.execute_query(sql))
+        return [dict(row) for row in rows]
+
+    def fetch_snapshot_rows(
+        self, as_of_date: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        sql = build_snapshot_sql(as_of_date=as_of_date, sb_database=self.sb_database)
+        return self._execute_query(sql)
+
+    def fetch_ventas_netas(self, as_of_date: str) -> tuple[float, int]:
+        sql = build_dso_sales_sql(
+            as_of_date=as_of_date,
+            dso_days=self.dso_days,
+            sb_database=self.sb_database,
+        )
+        rows = self._execute_query(sql)
+        if not rows:
+            return 0.0, self.dso_days
+        row = rows[0]
+        return (
+            _as_float(row.get("ventas_netas")),
+            _as_int(row.get("dias_periodo")) or self.dso_days,
+        )
+
+    def build_report(self, as_of_date: str) -> Dict[str, Any]:
+        as_of = validate_as_of_date(as_of_date)
+        rows = self.fetch_snapshot_rows(as_of)
+        ventas: Optional[float] = None
+        if self.include_dso:
+            ventas, _ = self.fetch_ventas_netas(as_of)
+        return build_report_from_rows(
+            rows,
+            as_of_date=as_of,
+            top_n=self.top_n,
+            dso_days=self.dso_days,
+            ventas_netas=ventas,
+            include_dso=self.include_dso,
+        )

--- a/src/business_analyzer/reports/cartera_aging.py
+++ b/src/business_analyzer/reports/cartera_aging.py
@@ -1,0 +1,330 @@
+"""Cartera / AR aging report builder for CLI and Vanna web UI."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+from business_analyzer.ai.base import Config
+from business_analyzer.ai.formatting import format_currency
+from business_analyzer.core.cartera_aging import CarteraAgingRunner
+from business_analyzer.core.database import Database
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def default_as_of_date(*, today: Optional[date] = None) -> str:
+    """Default as-of date: yesterday."""
+    ref = today or date.today()
+    return (ref - timedelta(days=1)).isoformat()
+
+
+def cartera_output_basename(as_of_date: str, fmt: str = "html") -> str:
+    ext = {
+        "html": "html",
+        "pdf": "pdf",
+        "markdown": "md",
+        "md": "md",
+        "json": "json",
+    }.get((fmt or "html").lower(), "html")
+    return f"CARTERA_AGING_{as_of_date}.{ext}"
+
+
+def validate_as_of_date(as_of_date: str) -> str:
+    raw = (as_of_date or "").strip()
+    if not _DATE_RE.fullmatch(raw):
+        raise ValueError(f"Fecha inválida (use YYYY-MM-DD): {as_of_date!r}")
+    date.fromisoformat(raw)
+    return raw
+
+
+def _fmt_money(value: Any) -> str:
+    try:
+        return str(format_currency(float(value), 0))
+    except (TypeError, ValueError):
+        return "—"
+
+
+def _fmt_pct(value: Any, decimals: int = 1) -> str:
+    try:
+        n = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    t = f"{n:,.{decimals}f}"
+    return t.replace(",", "X").replace(".", ",").replace("X", ".") + "%"
+
+
+def _fmt_num(value: Any, decimals: int = 0) -> str:
+    try:
+        n = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    if decimals == 0:
+        return f"{n:,.0f}".replace(",", ".")
+    t = f"{n:,.{decimals}f}"
+    return t.replace(",", "X").replace(".", ",").replace("X", ".")
+
+
+def _short(text: Any, n: int = 42) -> str:
+    s = str(text or "")
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    """Spanish decision markdown for a built cartera aging report dict."""
+    summary = report.get("summary") or {}
+    excluded = report.get("excluded_document_codes") or []
+    dso_window = int(report.get("dso_days_window") or 30)
+
+    lines = [
+        "# Cartera / Cuentas por Cobrar (Aging)",
+        "",
+        f"- **Fecha referencia:** {report.get('as_of_date')}",
+        f"- **Snapshot fecha_carga:** {report.get('fecha_carga_snapshot')}",
+        f"- **Fuente:** `{report.get('source') or 'banco_cartera'}` (último snapshot)",
+        f"- **Clientes con saldo:** {_fmt_num(summary.get('Clientes_Con_Saldo'), 0)}",
+        f"- **Filas documento (snapshot):** {_fmt_num(summary.get('Documentos_Filas'), 0)}",
+        "",
+        "## Resumen ejecutivo",
+        "",
+        f"- **Cartera total:** {_fmt_money(summary.get('Cartera_Total'))}",
+        f"- **Corriente (al día):** {_fmt_money(summary.get('Cartera_Corriente'))}",
+        (
+            f"- **Vencida:** {_fmt_money(summary.get('Cartera_Vencida'))} "
+            f"({_fmt_pct(summary.get('Cartera_Vencida_Pct'))})"
+        ),
+        (
+            f"- **Vencida >90 d:** {_fmt_money(summary.get('Cartera_Vencida_90_Plus'))} "
+            f"({_fmt_pct(summary.get('Cartera_Vencida_90_Plus_Pct'))})"
+        ),
+        f"- **Clientes sobre cupo:** {_fmt_num(summary.get('Clientes_Sobre_Cupo'), 0)}",
+        (
+            f"- **Días vencidos prom. ponderado:** "
+            f"{_fmt_num(summary.get('Dias_Vencidos_Promedio_Ponderado'), 1)}"
+        ),
+    ]
+    if summary.get("DSO_Dias") is not None:
+        lines.append(
+            f"- **DSO ({dso_window} d):** {_fmt_num(summary.get('DSO_Dias'), 1)} días "
+            f"(ventas netas periodo: {_fmt_money(summary.get('Ventas_Netas_Periodo'))})"
+        )
+        lines.append(
+            f"- **Exclusión ventas DSO (DocumentosCodigo):** "
+            + ", ".join(f"`{c}`" for c in excluded)
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Buckets de aging",
+            "",
+            "| Bucket | Monto | % cartera |",
+            "|---|---:|---:|",
+        ]
+    )
+    for b in report.get("buckets") or []:
+        lines.append(
+            f"| {b.get('label')} | {_fmt_money(b.get('amount'))} | "
+            f"{_fmt_pct(b.get('share_pct'))} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Top clientes vencidos",
+            "",
+            "| Cliente | Vendedor | Vencido | Total | Días | >90 d |",
+            "|---|---|---:|---:|---:|---:|",
+        ]
+    )
+    overdue = report.get("top_overdue") or []
+    if not overdue:
+        lines.append("| — | *(sin filas)* | — | — | — | — |")
+    for row in overdue:
+        lines.append(
+            f"| {_short(row.get('cliente_razon_social'))} | "
+            f"{_short(row.get('vendedor_nombre'), 20)} | "
+            f"{_fmt_money(row.get('vencido'))} | "
+            f"{_fmt_money(row.get('total'))} | "
+            f"{_fmt_num(row.get('dias_vencidos'), 0)} | "
+            f"{_fmt_money(row.get('vencido_90_plus'))} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Concentración de cartera (Top clientes)",
+            "",
+            "| Cliente | Total | % | % acum. | Vencido |",
+            "|---|---:|---:|---:|---:|",
+        ]
+    )
+    for row in report.get("top_concentration") or []:
+        lines.append(
+            f"| {_short(row.get('cliente_razon_social'))} | "
+            f"{_fmt_money(row.get('total'))} | "
+            f"{_fmt_pct(100 * float(row.get('share_total') or 0))} | "
+            f"{_fmt_pct(100 * float(row.get('share_acum') or 0))} | "
+            f"{_fmt_money(row.get('vencido'))} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Clientes sobre cupo de crédito",
+            "",
+            "| Cliente | Cupo | Total | Exceso | Vendedor |",
+            "|---|---:|---:|---:|---|",
+        ]
+    )
+    over = report.get("over_limit") or []
+    if not over:
+        lines.append("| — | *(ninguno sobre cupo)* | — | — | — |")
+    for row in over:
+        lines.append(
+            f"| {_short(row.get('cliente_razon_social'))} | "
+            f"{_fmt_money(row.get('cliente_cupo'))} | "
+            f"{_fmt_money(row.get('total'))} | "
+            f"{_fmt_money(row.get('exceso_cupo'))} | "
+            f"{_short(row.get('vendedor_nombre'), 20)} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Por vendedor",
+            "",
+            "| Vendedor | Clientes | Total | Vencido | >90 d |",
+            "|---|---:|---:|---:|---:|",
+        ]
+    )
+    for row in report.get("by_vendedor") or []:
+        lines.append(
+            f"| {_short(row.get('vendedor_nombre'), 28)} | "
+            f"{_fmt_num(row.get('clientes'), 0)} | "
+            f"{_fmt_money(row.get('total'))} | "
+            f"{_fmt_money(row.get('vencido'))} | "
+            f"{_fmt_money(row.get('vencido_90_plus'))} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Metodología",
+            "",
+            (
+                "1. **Snapshot:** `banco_cartera` con `fecha_carga = MAX(fecha_carga)` "
+                "(o el más reciente con fecha ≤ referencia)."
+            ),
+            (
+                "2. **Agregación:** saldos por cliente (`cliente_uid`); buckets "
+                "`corriente`, `vencido_30`…`vencido_superior`."
+            ),
+            (
+                "3. **% vencida / >90 d:** alineado a Q9 del KPI pack "
+                "(`vencido` y suma 90+120+360+superior sobre total)."
+            ),
+            (
+                f"4. **DSO (opcional):** cartera × {dso_window} / ventas netas del periodo; "
+                "ventas en `banco_datos` con "
+                f"`DocumentosCodigo NOT IN ({', '.join(excluded)})`."
+            ),
+            "5. **v1:** sin J3 `CarCarteraCliente`.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_cartera_result(
+    *,
+    as_of_date: str,
+    top_n: int = 25,
+    dso_days: int = 30,
+    include_dso: bool = True,
+    output_dir: Optional[Path] = None,
+    write_json: bool = False,
+    fmt: str = "html",
+    db: Optional[Database] = None,
+) -> Dict[str, Any]:
+    """Run cartera aging analysis and write HTML / PDF / markdown / JSON."""
+    try:
+        as_of = validate_as_of_date(as_of_date)
+    except ValueError as exc:
+        return {"status": "error", "message": str(exc)}
+
+    fmt_norm = (fmt or "html").strip().lower()
+    if fmt_norm in ("md", "markdown"):
+        fmt_norm = "markdown"
+    if fmt_norm not in ("html", "pdf", "markdown", "json"):
+        return {
+            "status": "error",
+            "message": (f"Formato inválido: {fmt!r} (use html, pdf, markdown o json)"),
+        }
+
+    try:
+        runner = CarteraAgingRunner(
+            db or Database(),
+            top_n=int(top_n),
+            dso_days=int(dso_days),
+            include_dso=bool(include_dso),
+        )
+        report = runner.build_report(as_of)
+    except Exception as exc:  # noqa: BLE001 — surface to API
+        return {
+            "status": "error",
+            "message": f"Error generando cartera / aging: {exc}",
+        }
+
+    from business_analyzer.reports.cartera_html import build_insights, render_html
+
+    insights = build_insights(report)
+    report = dict(report)
+    report["insights"] = insights
+
+    out_dir = Path(output_dir) if output_dir else Config.ensure_output_dir()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / cartera_output_basename(as_of, fmt_norm)
+
+    try:
+        if fmt_norm == "html":
+            path.write_text(render_html(report, insights=insights), encoding="utf-8")
+        elif fmt_norm == "pdf":
+            from business_analyzer.reports.cartera_pdf import write_cartera_pdf
+
+            write_cartera_pdf(report, path, insights=insights)
+        elif fmt_norm == "json":
+            path.write_text(json.dumps(report, indent=2, default=str), encoding="utf-8")
+        else:
+            path.write_text(render_markdown(report), encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "status": "error",
+            "message": f"Error escribiendo informe ({fmt_norm}): {exc}",
+        }
+
+    if write_json and fmt_norm != "json":
+        path.with_suffix(".json").write_text(
+            json.dumps(report, indent=2, default=str), encoding="utf-8"
+        )
+
+    summary = report.get("summary") or {}
+    filename = path.name
+    return {
+        "status": "success",
+        "format": fmt_norm if fmt_norm != "markdown" else "markdown",
+        "as_of_date": as_of,
+        "path": str(path.resolve()),
+        "summary": summary,
+        "insights_count": len(insights),
+        "message": (
+            f"Cartera / Aging generada — {as_of} ({fmt_norm.upper()})\n"
+            f"Total={_fmt_money(summary.get('Cartera_Total'))}, "
+            f"Vencida={_fmt_pct(summary.get('Cartera_Vencida_Pct'))}, "
+            f">90d={_fmt_pct(summary.get('Cartera_Vencida_90_Plus_Pct'))}\n"
+            f"Insights={len(insights)} · Archivo: {filename}"
+        ),
+    }

--- a/src/business_analyzer/reports/cartera_html.py
+++ b/src/business_analyzer/reports/cartera_html.py
@@ -1,0 +1,699 @@
+"""Aesthetic HTML (+ print-friendly) for Cartera / AR aging."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from html import escape
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from business_analyzer.ai.formatting import format_currency
+
+
+def _money(value: Any) -> str:
+    try:
+        return str(format_currency(float(value), 0))
+    except (TypeError, ValueError):
+        return "—"
+
+
+def _f(value: Any, decimals: int = 0) -> str:
+    try:
+        n = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    if decimals == 0:
+        return f"{n:,.0f}".replace(",", ".")
+    t = f"{n:,.{decimals}f}"
+    return t.replace(",", "X").replace(".", ",").replace("X", ".")
+
+
+def _pct(value: Any, decimals: int = 1) -> str:
+    try:
+        n = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    return _f(n, decimals) + "%"
+
+
+def _short(text: Any, n: int = 48) -> str:
+    s = str(text or "")
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def build_insights(report: Mapping[str, Any]) -> List[Dict[str, str]]:
+    """Rule-based managerial insights (Spanish) from a cartera report dict."""
+    summary = report.get("summary") or {}
+    as_of = report.get("as_of_date") or ""
+    snapshot = (
+        report.get("fecha_carga_snapshot") or summary.get("Fecha_Carga_Cartera") or ""
+    )
+    total = float(summary.get("Cartera_Total") or 0)
+    corriente = float(summary.get("Cartera_Corriente") or 0)
+    vencida = float(summary.get("Cartera_Vencida") or 0)
+    vencida_pct = float(summary.get("Cartera_Vencida_Pct") or 0)
+    v90 = float(summary.get("Cartera_Vencida_90_Plus") or 0)
+    v90_pct = float(summary.get("Cartera_Vencida_90_Plus_Pct") or 0)
+    clientes = int(summary.get("Clientes_Con_Saldo") or 0)
+    sobre = int(summary.get("Clientes_Sobre_Cupo") or 0)
+    dias_prom = float(summary.get("Dias_Vencidos_Promedio_Ponderado") or 0)
+    dso = summary.get("DSO_Dias")
+    top_od = list(report.get("top_overdue") or [])
+    conc = list(report.get("top_concentration") or [])
+    over = list(report.get("over_limit") or [])
+    by_v = list(report.get("by_vendedor") or [])
+    dso_window = int(report.get("dso_days_window") or 30)
+
+    insights: List[Dict[str, str]] = []
+
+    # ── 1. Executive pulse ────────────────────────────────────────────
+    if vencida_pct >= 45 or v90_pct >= 15:
+        sev = "danger"
+        tone = (
+            "La cartera está <strong>bajo presión de cobranza</strong>: "
+            "priorice visitas y acuerdos de pago en el top vencido y frene "
+            "crédito nuevo a clientes en mora >90 d."
+        )
+    elif vencida_pct >= 30 or v90_pct >= 10:
+        sev = "warning"
+        tone = (
+            "Nivel de mora <strong>moderado-alto</strong>: hay espacio para "
+            "recuperar capital de trabajo con un plan de 7 días enfocado."
+        )
+    else:
+        sev = "info"
+        tone = (
+            "Mora contenida en términos relativos; mantenga disciplina de cupo "
+            "y no deje que el tramo 31–90 d se envejezca a >90 d."
+        )
+
+    insights.append(
+        {
+            "title": "Pulso ejecutivo de cartera",
+            "severity": sev,
+            "body": (
+                f"Al <strong>{escape(str(as_of))}</strong> "
+                f"(snapshot <code>{escape(str(snapshot))}</code>), la cartera total es "
+                f"<strong>{_money(total)}</strong> en "
+                f"<strong>{_f(clientes)}</strong> clientes con saldo: "
+                f"corriente <strong>{_money(corriente)}</strong>, "
+                f"vencida <strong>{_money(vencida)}</strong> "
+                f"(<strong>{_pct(vencida_pct)}</strong>), "
+                f"de la cual >90 d representa <strong>{_money(v90)}</strong> "
+                f"(<strong>{_pct(v90_pct)}</strong>). "
+                f"Días vencidos promedio ponderado: "
+                f"<strong>{_f(dias_prom, 1)}</strong>. {tone}"
+            ),
+        }
+    )
+
+    # ── 2. Current vs overdue mix ─────────────────────────────────────
+    if total > 0:
+        insights.append(
+            {
+                "title": "Corriente vs vencida",
+                "severity": "warning" if vencida_pct >= 35 else "info",
+                "body": (
+                    f"Del total, <strong>{_pct(100 * corriente / total if total else 0)}</strong> "
+                    f"está al día y <strong>{_pct(vencida_pct)}</strong> está vencida. "
+                    f"Meta operativa: bajar el tramo >90 d por debajo del 12% "
+                    f"(hoy <strong>{_pct(v90_pct)}</strong>) con acuerdos de pronto pago "
+                    "y suspensión de despachos a crédito cuando corresponda."
+                ),
+            }
+        )
+
+    # ── 3. Top overdue narrative ──────────────────────────────────────
+    if top_od:
+        lines = []
+        for row in top_od[:5]:
+            lines.append(
+                f"<li><strong>{escape(_short(row.get('cliente_razon_social'), 50))}</strong>"
+                f" · vendedor {escape(_short(row.get('vendedor_nombre'), 24))} · "
+                f"vencido <strong>{_money(row.get('vencido'))}</strong> · "
+                f"total {_money(row.get('total'))} · "
+                f"{_f(row.get('dias_vencidos'))} d · "
+                f">90 d {_money(row.get('vencido_90_plus'))}</li>"
+            )
+        sum_top = sum(float(r.get("vencido") or 0) for r in top_od[:10])
+        insights.append(
+            {
+                "title": "Prioridad de cobranza (top vencidos)",
+                "severity": "danger" if vencida_pct >= 40 else "warning",
+                "body": (
+                    f"Los primeros <strong>{_f(min(len(top_od), 10))}</strong> clientes "
+                    f"concentran ~<strong>{_money(sum_top)}</strong> de mora en el listado. "
+                    "Top a contactar esta semana:"
+                    f"<ol>{''.join(lines)}</ol>"
+                    "Acción: llamada + compromiso escrito de pago; escalar a gerencia "
+                    "comercial si superan cupo o llevan >90 d."
+                ),
+            }
+        )
+
+    # ── 4. Concentration ──────────────────────────────────────────────
+    if conc:
+        top3 = conc[:3]
+        acum3 = float(top3[-1].get("share_acum") or 0) if top3 else 0
+        top10 = conc[:10]
+        acum10 = float(top10[-1].get("share_acum") or 0) if top10 else 0
+        bits = "; ".join(
+            f"<em>{escape(_short(c.get('cliente_razon_social'), 36))}</em> "
+            f"({_pct(100 * float(c.get('share_total') or 0))})"
+            for c in top3
+        )
+        sev_c = "warning" if acum10 >= 0.40 else "info"
+        insights.append(
+            {
+                "title": "Concentración de riesgo de crédito",
+                "severity": sev_c,
+                "body": (
+                    f"Top 3 clientes = <strong>{_pct(100 * acum3)}</strong> de la cartera; "
+                    f"Top 10 ≈ <strong>{_pct(100 * acum10)}</strong>. "
+                    f"Mayores saldos: {bits}. "
+                    "Vigile cupos y plazos de estos nombres: un default en el top "
+                    "impacta caja de forma desproporcionada."
+                ),
+            }
+        )
+
+    # ── 5. Over credit limit ──────────────────────────────────────────
+    if sobre > 0 or over:
+        lines = []
+        for row in over[:5]:
+            lines.append(
+                f"<li><strong>{escape(_short(row.get('cliente_razon_social'), 45))}</strong> · "
+                f"cupo {_money(row.get('cliente_cupo'))} · "
+                f"saldo {_money(row.get('total'))} · "
+                f"exceso <strong>{_money(row.get('exceso_cupo'))}</strong></li>"
+            )
+        insights.append(
+            {
+                "title": "Clientes sobre cupo de crédito",
+                "severity": "danger" if sobre >= 5 else "warning",
+                "body": (
+                    f"Hay <strong>{_f(sobre)}</strong> cliente(s) con saldo por encima del cupo. "
+                    + ("Ejemplos:" f"<ol>{''.join(lines)}</ol>" if lines else "")
+                    + "Congelar pedidos a crédito hasta regularizar o ampliar cupo "
+                    "con aprobación formal."
+                ),
+            }
+        )
+    else:
+        insights.append(
+            {
+                "title": "Cupos de crédito",
+                "severity": "success",
+                "body": (
+                    "No hay clientes sobre cupo en el snapshot. Mantenga la revisión "
+                    "periódica de límites vs comportamiento de pago."
+                ),
+            }
+        )
+
+    # ── 6. DSO ────────────────────────────────────────────────────────
+    if dso is not None:
+        try:
+            dso_f = float(dso)
+        except (TypeError, ValueError):
+            dso_f = None
+        if dso_f is not None:
+            if dso_f > 55:
+                dso_sev = "danger"
+                dso_msg = (
+                    "DSO elevado: el ciclo de cobro está lento vs una meta típica "
+                    "de ~45 días para ferretería B2B."
+                )
+            elif dso_f > 45:
+                dso_sev = "warning"
+                dso_msg = (
+                    "DSO por encima de la meta de 45 días; acelere cobranza de >60 d."
+                )
+            else:
+                dso_sev = "success"
+                dso_msg = "DSO dentro o bajo la meta de 45 días."
+            insights.append(
+                {
+                    "title": f"DSO (ventana {dso_window} d)",
+                    "severity": dso_sev,
+                    "body": (
+                        f"DSO calculado: <strong>{_f(dso_f, 1)} días</strong> "
+                        f"(cartera / ventas diarias netas del periodo). "
+                        f"Ventas netas usadas: {_money(summary.get('Ventas_Netas_Periodo'))}. "
+                        f"{dso_msg}"
+                    ),
+                }
+            )
+
+    # ── 7. By seller ──────────────────────────────────────────────────
+    if by_v:
+        worst = max(by_v, key=lambda x: float(x.get("vencido") or 0))
+        biggest = max(by_v, key=lambda x: float(x.get("total") or 0))
+        insights.append(
+            {
+                "title": "Cartera por vendedor",
+                "severity": "warning",
+                "body": (
+                    f"<strong>{escape(str(worst.get('vendedor_nombre')))}</strong> concentra "
+                    f"la mayor mora (<strong>{_money(worst.get('vencido'))}</strong>). "
+                    f"<strong>{escape(str(biggest.get('vendedor_nombre')))}</strong> lidera "
+                    f"en saldo total (<strong>{_money(biggest.get('total'))}</strong>). "
+                    "Asigne metas de recaudo semanal por vendedor sobre su top 5 vencido."
+                ),
+            }
+        )
+
+    # ── 8. 7-day plan ─────────────────────────────────────────────────
+    n_od = min(len(top_od), 15)
+    n_ol = min(len(over), 10)
+    insights.append(
+        {
+            "title": "Plan de cobranza — próximos 7 días",
+            "severity": "success",
+            "body": (
+                "<ol>"
+                f"<li><strong>Hoy–mañana:</strong> contactar los "
+                f"<strong>{_f(min(n_od, 5))}</strong> mayores vencidos; "
+                "documentar promesa de pago y fecha.</li>"
+                f"<li><strong>Esta semana:</strong> recorrer hasta "
+                f"<strong>{_f(n_od)}</strong> cuentas del listado de mora y las "
+                f"<strong>{_f(n_ol)}</strong> sobre cupo; bloquear crédito si no hay plan.</li>"
+                f"<li><strong>Comercial:</strong> alinear vendedores con meta de recaudo "
+                f"sobre su cartera vencida (hoy total mora {_money(vencida)}).</li>"
+                f"<li><strong>Riesgo:</strong> revisar >90 d "
+                f"({_money(v90)}, {_pct(v90_pct)}) para castigo, acuerdo o jurídico.</li>"
+                "<li><strong>Seguimiento:</strong> regenerar este informe en 7 días y "
+                "comparar % vencida, >90 d, DSO y clientes sobre cupo.</li>"
+                "</ol>"
+            ),
+        }
+    )
+    return insights
+
+
+def _sev_class(sev: str) -> str:
+    return {
+        "danger": "insight-danger",
+        "warning": "insight-warning",
+        "success": "insight-success",
+        "info": "insight-info",
+    }.get(sev, "insight-info")
+
+
+def _table_rows(
+    rows: Sequence[Mapping[str, Any]],
+    cols: Sequence[tuple],
+    limit: int = 20,
+) -> str:
+    if not rows:
+        return "<tr><td colspan='99' class='empty'>Sin filas en este corte</td></tr>"
+    parts = []
+    for r in list(rows)[:limit]:
+        tds = []
+        for _h, key, align in cols:
+            if callable(key):
+                val = key(r)
+            else:
+                val = r.get(key)
+            tds.append(f"<td class='{align}'>{val}</td>")
+        parts.append("<tr>" + "".join(tds) + "</tr>")
+    return "\n".join(parts)
+
+
+def render_html(
+    report: Mapping[str, Any],
+    *,
+    insights: Optional[List[Dict[str, str]]] = None,
+) -> str:
+    """Self-contained aesthetic HTML report in Spanish."""
+    summary = report.get("summary") or {}
+    insights = insights if insights is not None else build_insights(report)
+    as_of = escape(str(report.get("as_of_date") or ""))
+    snapshot = escape(str(report.get("fecha_carga_snapshot") or ""))
+    generated = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+    overdue_cols = [
+        (
+            "Cliente",
+            lambda r: escape(_short(r.get("cliente_razon_social"))),
+            "left",
+        ),
+        (
+            "Vendedor",
+            lambda r: escape(_short(r.get("vendedor_nombre"), 22)),
+            "left",
+        ),
+        ("Vencido", lambda r: _money(r.get("vencido")), "num"),
+        ("Total", lambda r: _money(r.get("total")), "num"),
+        ("Días", lambda r: _f(r.get("dias_vencidos")), "num"),
+        (">90 d", lambda r: _money(r.get("vencido_90_plus")), "num"),
+    ]
+    conc_cols = [
+        (
+            "Cliente",
+            lambda r: escape(_short(r.get("cliente_razon_social"))),
+            "left",
+        ),
+        ("Total", lambda r: _money(r.get("total")), "num"),
+        (
+            "%",
+            lambda r: _pct(100 * float(r.get("share_total") or 0)),
+            "num",
+        ),
+        (
+            "% acum.",
+            lambda r: _pct(100 * float(r.get("share_acum") or 0)),
+            "num",
+        ),
+        ("Vencido", lambda r: _money(r.get("vencido")), "num"),
+    ]
+    over_cols = [
+        (
+            "Cliente",
+            lambda r: escape(_short(r.get("cliente_razon_social"))),
+            "left",
+        ),
+        ("Cupo", lambda r: _money(r.get("cliente_cupo")), "num"),
+        ("Total", lambda r: _money(r.get("total")), "num"),
+        ("Exceso", lambda r: _money(r.get("exceso_cupo")), "num"),
+        (
+            "Vendedor",
+            lambda r: escape(_short(r.get("vendedor_nombre"), 22)),
+            "left",
+        ),
+    ]
+    vend_cols = [
+        (
+            "Vendedor",
+            lambda r: escape(_short(r.get("vendedor_nombre"), 32)),
+            "left",
+        ),
+        ("Clientes", lambda r: _f(r.get("clientes")), "num"),
+        ("Total", lambda r: _money(r.get("total")), "num"),
+        ("Vencido", lambda r: _money(r.get("vencido")), "num"),
+        (">90 d", lambda r: _money(r.get("vencido_90_plus")), "num"),
+    ]
+
+    insight_html = "\n".join(
+        f"""
+        <article class="insight {_sev_class(i.get('severity', 'info'))}">
+          <div class="insight-head">
+            <span class="insight-num">{idx}</span>
+            <h3>{escape(i.get('title', ''))}</h3>
+            <span class="sev-tag sev-{escape(str(i.get('severity') or 'info'))}">{escape(str(i.get('severity') or 'info').upper())}</span>
+          </div>
+          <div class="insight-body">{i.get('body', '')}</div>
+        </article>
+        """
+        for idx, i in enumerate(insights, 1)
+    )
+
+    bucket_cards = "\n".join(
+        f"""
+        <div class="wh-card">
+          <div class="wh-code">{escape(str(b.get('label') or ''))}</div>
+          <div class="wh-stock">{_money(b.get('amount'))}</div>
+          <div class="wh-name">{_pct(b.get('share_pct'))} de la cartera</div>
+        </div>
+        """
+        for b in (report.get("buckets") or [])
+    )
+
+    dso_kpi = ""
+    if summary.get("DSO_Dias") is not None:
+        dso_kpi = (
+            f'<div class="kpi"><div class="label">DSO (d)</div>'
+            f'<div class="value">{_f(summary.get("DSO_Dias"), 1)}</div></div>'
+        )
+
+    return f"""<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cartera / Aging — {as_of}</title>
+  <style>
+    :root {{
+      --primary: #0f2744;
+      --secondary: #1d4ed8;
+      --accent: #059669;
+      --warning: #d97706;
+      --danger: #dc2626;
+      --bg: #f1f5f9;
+      --card: #ffffff;
+      --text: #0f172a;
+      --muted: #64748b;
+      --border: #e2e8f0;
+    }}
+    * {{ box-sizing: border-box; margin: 0; padding: 0; }}
+    body {{
+      font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.55;
+    }}
+    .wrap {{ max-width: 1180px; margin: 0 auto; padding: 1.5rem 1.25rem 3rem; }}
+    header.hero {{
+      background: linear-gradient(135deg, #0f2744 0%, #7c2d12 55%, #ea580c 100%);
+      color: #fff;
+      border-radius: 1.25rem;
+      padding: 2rem 1.75rem;
+      margin-bottom: 1.5rem;
+      box-shadow: 0 20px 40px rgba(15, 39, 68, 0.25);
+    }}
+    header.hero h1 {{ font-size: 1.85rem; font-weight: 750; letter-spacing: -0.02em; }}
+    header.hero .sub {{ opacity: 0.92; margin-top: 0.4rem; font-size: 0.98rem; }}
+    header.hero .meta {{
+      margin-top: 1rem;
+      display: flex; flex-wrap: wrap; gap: 0.5rem;
+    }}
+    .chip {{
+      background: rgba(255,255,255,0.16);
+      border: 1px solid rgba(255,255,255,0.25);
+      padding: 0.3rem 0.7rem;
+      border-radius: 999px;
+      font-size: 0.78rem;
+      font-weight: 600;
+    }}
+    .kpi-grid {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 0.85rem;
+      margin-bottom: 1.5rem;
+    }}
+    .kpi {{
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 1rem;
+      padding: 1rem 0.9rem;
+      text-align: center;
+      box-shadow: 0 4px 14px rgba(15, 23, 42, 0.04);
+    }}
+    .kpi .label {{ font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); }}
+    .kpi .value {{ font-size: 1.2rem; font-weight: 750; color: var(--primary); margin-top: 0.25rem; }}
+    .kpi .value.danger {{ color: var(--danger); }}
+    .kpi .value.warning {{ color: var(--warning); }}
+    .kpi .value.success {{ color: var(--accent); }}
+    section {{
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 1.1rem;
+      padding: 1.25rem 1.35rem;
+      margin-bottom: 1.25rem;
+      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.04);
+    }}
+    section h2 {{
+      font-size: 1.15rem;
+      margin-bottom: 0.85rem;
+      color: var(--primary);
+      border-bottom: 2px solid #fed7aa;
+      padding-bottom: 0.45rem;
+    }}
+    .insights {{ display: grid; gap: 0.85rem; }}
+    .insight {{
+      border-radius: 0.95rem;
+      padding: 1rem 1.1rem;
+      border-left: 5px solid #94a3b8;
+      background: #f8fafc;
+    }}
+    .insight-head {{
+      display: flex; align-items: center; gap: 0.55rem; flex-wrap: wrap;
+      margin-bottom: 0.45rem;
+    }}
+    .insight-num {{
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 1.55rem; height: 1.55rem; border-radius: 999px;
+      background: var(--primary); color: #fff; font-size: 0.75rem; font-weight: 800;
+    }}
+    .insight h3 {{ font-size: 0.98rem; margin: 0; flex: 1 1 auto; }}
+    .sev-tag {{
+      font-size: 0.65rem; font-weight: 800; letter-spacing: 0.04em;
+      padding: 0.15rem 0.45rem; border-radius: 999px; text-transform: uppercase;
+    }}
+    .sev-danger {{ background: #fee2e2; color: #991b1b; }}
+    .sev-warning {{ background: #fef3c7; color: #92400e; }}
+    .sev-success {{ background: #dcfce7; color: #166534; }}
+    .sev-info {{ background: #dbeafe; color: #1e40af; }}
+    .insight-body {{ font-size: 0.92rem; color: #334155; }}
+    .insight-body ol {{ margin: 0.45rem 0 0.35rem 1.25rem; }}
+    .insight-body li {{ margin-bottom: 0.25rem; }}
+    .insight-danger {{ border-left-color: var(--danger); background: #fef2f2; }}
+    .insight-danger .insight-num {{ background: var(--danger); }}
+    .insight-warning {{ border-left-color: var(--warning); background: #fffbeb; }}
+    .insight-warning .insight-num {{ background: var(--warning); }}
+    .insight-success {{ border-left-color: var(--accent); background: #ecfdf5; }}
+    .insight-success .insight-num {{ background: var(--accent); }}
+    .insight-info {{ border-left-color: var(--secondary); background: #eff6ff; }}
+    .insight-info .insight-num {{ background: var(--secondary); }}
+    .section-lead {{ font-size: 0.88rem; color: var(--muted); margin: -0.35rem 0 0.85rem; }}
+    table {{ width: 100%; border-collapse: collapse; font-size: 0.86rem; }}
+    th {{
+      text-align: left; background: #f1f5f9; color: #334155; font-weight: 650;
+      padding: 0.55rem 0.5rem; border-bottom: 1px solid var(--border); white-space: nowrap;
+    }}
+    td {{ padding: 0.5rem; border-bottom: 1px solid #f1f5f9; vertical-align: top; }}
+    td.num {{ text-align: right; font-variant-numeric: tabular-nums; }}
+    td.center {{ text-align: center; }}
+    td.empty {{ text-align: center; color: var(--muted); padding: 1rem; }}
+    tr:hover td {{ background: #f8fafc; }}
+    .wh-grid {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 0.75rem;
+    }}
+    .wh-card {{
+      border: 1px solid var(--border);
+      border-radius: 0.9rem;
+      padding: 0.85rem;
+      background: linear-gradient(180deg, #fff, #fff7ed);
+    }}
+    .wh-code {{ font-weight: 700; font-size: 0.82rem; color: var(--primary); }}
+    .wh-name {{ font-size: 0.78rem; color: var(--muted); margin-top: 0.25rem; }}
+    .wh-stock {{ font-size: 1.05rem; font-weight: 750; color: #9a3412; margin-top: 0.35rem; }}
+    footer {{ text-align: center; color: var(--muted); font-size: 0.8rem; margin-top: 1rem; }}
+    code {{ font-size: 0.82em; background: #f1f5f9; padding: 0.05rem 0.3rem; border-radius: 0.3rem; }}
+    @media print {{
+      body {{ background: #fff; }}
+      header.hero {{ box-shadow: none; -webkit-print-color-adjust: exact; print-color-adjust: exact; }}
+      section {{ box-shadow: none; break-inside: avoid; }}
+    }}
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header class="hero">
+      <h1>Cartera / Cuentas por Cobrar</h1>
+      <p class="sub">Aging, mora, concentración, cupos y plan de cobranza · Deposito Trujillo</p>
+      <div class="meta">
+        <span class="chip">Fecha {as_of}</span>
+        <span class="chip">Snapshot {snapshot}</span>
+        <span class="chip">banco_cartera</span>
+        <span class="chip">Generado {escape(generated)}</span>
+      </div>
+    </header>
+
+    <div class="kpi-grid">
+      <div class="kpi"><div class="label">Cartera total</div><div class="value">{_money(summary.get('Cartera_Total'))}</div></div>
+      <div class="kpi"><div class="label">Corriente</div><div class="value success">{_money(summary.get('Cartera_Corriente'))}</div></div>
+      <div class="kpi"><div class="label">Vencida</div><div class="value danger">{_money(summary.get('Cartera_Vencida'))}</div></div>
+      <div class="kpi"><div class="label">% Vencida</div><div class="value warning">{_pct(summary.get('Cartera_Vencida_Pct'))}</div></div>
+      <div class="kpi"><div class="label">% >90 d</div><div class="value danger">{_pct(summary.get('Cartera_Vencida_90_Plus_Pct'))}</div></div>
+      <div class="kpi"><div class="label">Clientes</div><div class="value">{_f(summary.get('Clientes_Con_Saldo'))}</div></div>
+      <div class="kpi"><div class="label">Sobre cupo</div><div class="value warning">{_f(summary.get('Clientes_Sobre_Cupo'))}</div></div>
+      {dso_kpi}
+    </div>
+
+    <section>
+      <h2>Insights y plan de cobranza</h2>
+      <p class="section-lead">
+        Lectura gerencial automática: total AR, corriente vs vencida, top mora,
+        concentración, cupos y plan a 7 días.
+      </p>
+      <div class="insights">{insight_html}</div>
+    </section>
+
+    <section>
+      <h2>Buckets de aging</h2>
+      <div class="wh-grid">{bucket_cards or '<p class="empty">Sin buckets</p>'}</div>
+    </section>
+
+    <section>
+      <h2>Top clientes vencidos</h2>
+      <p class="section-lead">Prioridad de contacto para cobranza.</p>
+      <div style="overflow-x:auto">
+      <table>
+        <thead><tr>
+          <th>Cliente</th><th>Vendedor</th><th class="num">Vencido</th>
+          <th class="num">Total</th><th class="num">Días</th><th class="num">>90 d</th>
+        </tr></thead>
+        <tbody>
+          {_table_rows(report.get('top_overdue') or [], overdue_cols, 25)}
+        </tbody>
+      </table>
+      </div>
+    </section>
+
+    <section>
+      <h2>Concentración de cartera</h2>
+      <div style="overflow-x:auto">
+      <table>
+        <thead><tr>
+          <th>Cliente</th><th class="num">Total</th><th class="num">%</th>
+          <th class="num">% acum.</th><th class="num">Vencido</th>
+        </tr></thead>
+        <tbody>
+          {_table_rows(report.get('top_concentration') or [], conc_cols, 25)}
+        </tbody>
+      </table>
+      </div>
+    </section>
+
+    <section>
+      <h2>Clientes sobre cupo</h2>
+      <div style="overflow-x:auto">
+      <table>
+        <thead><tr>
+          <th>Cliente</th><th class="num">Cupo</th><th class="num">Total</th>
+          <th class="num">Exceso</th><th>Vendedor</th>
+        </tr></thead>
+        <tbody>
+          {_table_rows(report.get('over_limit') or [], over_cols, 25)}
+        </tbody>
+      </table>
+      </div>
+    </section>
+
+    <section>
+      <h2>Por vendedor</h2>
+      <div style="overflow-x:auto">
+      <table>
+        <thead><tr>
+          <th>Vendedor</th><th class="num">Clientes</th><th class="num">Total</th>
+          <th class="num">Vencido</th><th class="num">>90 d</th>
+        </tr></thead>
+        <tbody>
+          {_table_rows(report.get('by_vendedor') or [], vend_cols, 20)}
+        </tbody>
+      </table>
+      </div>
+    </section>
+
+    <section>
+      <h2>Metodología</h2>
+      <div class="insight-body" style="font-size:0.9rem;color:#475569">
+        <p><strong>Fuente:</strong> SmartBusiness <code>banco_cartera</code>,
+        snapshot con <code>fecha_carga = MAX(fecha_carga)</code>
+        (o el más reciente ≤ fecha de referencia).</p>
+        <p style="margin-top:0.5rem"><strong>KPIs:</strong> alineados a Q9 del pack KPI
+        (% vencida, % >90 d, clientes sobre cupo, DSO opcional via
+        <code>banco_datos</code> excluyendo códigos de prueba).</p>
+        <p style="margin-top:0.5rem"><strong>v1:</strong> no usa J3 <code>CarCarteraCliente</code>.</p>
+      </div>
+    </section>
+
+    <footer>
+      Deposito Trujillo · Business Data Analyzer · Cartera Aging · {escape(generated)}
+    </footer>
+  </div>
+</body>
+</html>
+"""

--- a/src/business_analyzer/reports/cartera_pdf.py
+++ b/src/business_analyzer/reports/cartera_pdf.py
@@ -1,0 +1,294 @@
+"""PDF export for Cartera / AR aging (ReportLab)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from business_analyzer.ai.formatting import format_currency
+
+try:
+    from reportlab.lib import colors
+    from reportlab.lib.enums import TA_CENTER
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+    from reportlab.lib.units import cm
+    from reportlab.platypus import (
+        Paragraph,
+        SimpleDocTemplate,
+        Spacer,
+        Table,
+        TableStyle,
+    )
+
+    REPORTLAB_AVAILABLE = True
+except ImportError:
+    REPORTLAB_AVAILABLE = False
+
+
+def _money(value: Any) -> str:
+    try:
+        return str(format_currency(float(value), 0))
+    except (TypeError, ValueError):
+        return "—"
+
+
+def _f(value: Any, decimals: int = 0) -> str:
+    try:
+        n = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    if decimals == 0:
+        return f"{n:,.0f}".replace(",", ".")
+    t = f"{n:,.{decimals}f}"
+    return t.replace(",", "X").replace(".", ",").replace("X", ".")
+
+
+def _pct(value: Any, decimals: int = 1) -> str:
+    try:
+        n = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    return _f(n, decimals) + "%"
+
+
+def _short(text: Any, n: int = 36) -> str:
+    s = str(text or "")
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def _strip_html(text: str) -> str:
+    import re
+
+    t = text or ""
+    t = re.sub(r"<br\s*/?>", "\n", t, flags=re.I)
+    t = re.sub(r"</?(strong|em|code|p|div|span)[^>]*>", "", t, flags=re.I)
+    t = re.sub(r"</?ol[^>]*>", "\n", t, flags=re.I)
+    t = re.sub(r"<li[^>]*>", "• ", t, flags=re.I)
+    t = re.sub(r"</li>", "\n", t, flags=re.I)
+    t = re.sub(r"<[^>]+>", "", t)
+    return " ".join(t.split())
+
+
+def write_cartera_pdf(
+    report: Mapping[str, Any],
+    path: Path,
+    *,
+    insights: Optional[List[Dict[str, str]]] = None,
+) -> Path:
+    if not REPORTLAB_AVAILABLE:
+        raise RuntimeError(
+            "ReportLab no está instalado. Instálelo con: pip install reportlab"
+        )
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    styles = getSampleStyleSheet()
+    styles.add(
+        ParagraphStyle(
+            name="CarTitle",
+            parent=styles["Heading1"],
+            fontSize=18,
+            textColor=colors.HexColor("#0f2744"),
+            spaceAfter=8,
+            alignment=TA_CENTER,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="CarH2",
+            parent=styles["Heading2"],
+            fontSize=12,
+            textColor=colors.HexColor("#9a3412"),
+            spaceBefore=12,
+            spaceAfter=6,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="CarBody",
+            parent=styles["Normal"],
+            fontSize=9,
+            leading=12,
+            textColor=colors.HexColor("#334155"),
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="CarSmall",
+            parent=styles["Normal"],
+            fontSize=8,
+            textColor=colors.HexColor("#64748b"),
+            alignment=TA_CENTER,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            name="CarInsight",
+            parent=styles["Normal"],
+            fontSize=9,
+            leading=11,
+            textColor=colors.HexColor("#1e293b"),
+            leftIndent=4,
+            spaceAfter=6,
+        )
+    )
+
+    summary = report.get("summary") or {}
+    as_of = report.get("as_of_date") or ""
+    story: list = []
+    story.append(Paragraph("Cartera / Cuentas por Cobrar", styles["CarTitle"]))
+    story.append(
+        Paragraph(
+            f"Fecha {as_of} · snapshot {report.get('fecha_carga_snapshot') or '—'}",
+            styles["CarSmall"],
+        )
+    )
+    story.append(Spacer(1, 0.35 * cm))
+
+    kpi_data = [
+        ["Total", "Corriente", "Vencida", "% Ven.", "% >90d", "Sobre cupo"],
+        [
+            _money(summary.get("Cartera_Total")),
+            _money(summary.get("Cartera_Corriente")),
+            _money(summary.get("Cartera_Vencida")),
+            _pct(summary.get("Cartera_Vencida_Pct")),
+            _pct(summary.get("Cartera_Vencida_90_Plus_Pct")),
+            _f(summary.get("Clientes_Sobre_Cupo")),
+        ],
+    ]
+    kpi_t = Table(kpi_data, colWidths=[2.8 * cm] * 6)
+    kpi_t.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#7c2d12")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 8),
+                ("ALIGN", (0, 0), (-1, -1), "CENTER"),
+                ("BACKGROUND", (0, 1), (-1, 1), colors.HexColor("#fff7ed")),
+                ("GRID", (0, 0), (-1, -1), 0.4, colors.HexColor("#cbd5e1")),
+                ("TOPPADDING", (0, 0), (-1, -1), 5),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 5),
+            ]
+        )
+    )
+    story.append(kpi_t)
+    story.append(Spacer(1, 0.4 * cm))
+
+    if insights is None:
+        from business_analyzer.reports.cartera_html import build_insights
+
+        insights = build_insights(report)
+
+    story.append(Paragraph("Insights y plan de cobranza", styles["CarH2"]))
+    for ins in insights:
+        title = ins.get("title") or "Insight"
+        body = _strip_html(ins.get("body") or "")
+        story.append(Paragraph(f"<b>{title}.</b> {body}", styles["CarInsight"]))
+
+    def add_table(
+        title: str,
+        headers: Sequence[str],
+        rows: Sequence[Sequence[str]],
+        widths: Optional[Sequence[float]] = None,
+    ) -> None:
+        story.append(Paragraph(title, styles["CarH2"]))
+        if not rows:
+            story.append(Paragraph("Sin filas en este corte.", styles["CarBody"]))
+            return
+        data = [list(headers)] + [list(r) for r in rows[:20]]
+        t = Table(data, colWidths=list(widths) if widths else None, repeatRows=1)
+        t.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#9a3412")),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 7.5),
+                    ("GRID", (0, 0), (-1, -1), 0.3, colors.HexColor("#cbd5e1")),
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                    ("TOPPADDING", (0, 0), (-1, -1), 3),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+                    (
+                        "ROWBACKGROUNDS",
+                        (0, 1),
+                        (-1, -1),
+                        [colors.white, colors.HexColor("#f8fafc")],
+                    ),
+                ]
+            )
+        )
+        story.append(t)
+
+    bucket_rows = []
+    for b in report.get("buckets") or []:
+        bucket_rows.append(
+            [
+                str(b.get("label") or ""),
+                _money(b.get("amount")),
+                _pct(b.get("share_pct")),
+            ]
+        )
+    add_table(
+        "Buckets de aging",
+        ["Bucket", "Monto", "%"],
+        bucket_rows,
+        [8 * cm, 4 * cm, 3 * cm],
+    )
+
+    od_rows = []
+    for r in report.get("top_overdue") or []:
+        od_rows.append(
+            [
+                _short(r.get("cliente_razon_social"), 28),
+                _short(r.get("vendedor_nombre"), 16),
+                _money(r.get("vencido")),
+                _money(r.get("total")),
+                _f(r.get("dias_vencidos")),
+            ]
+        )
+    add_table(
+        "Top clientes vencidos",
+        ["Cliente", "Vendedor", "Vencido", "Total", "Días"],
+        od_rows,
+        [5.5 * cm, 3.2 * cm, 2.5 * cm, 2.5 * cm, 1.5 * cm],
+    )
+
+    ol_rows = []
+    for r in report.get("over_limit") or []:
+        ol_rows.append(
+            [
+                _short(r.get("cliente_razon_social"), 30),
+                _money(r.get("cliente_cupo")),
+                _money(r.get("total")),
+                _money(r.get("exceso_cupo")),
+            ]
+        )
+    add_table(
+        "Clientes sobre cupo",
+        ["Cliente", "Cupo", "Total", "Exceso"],
+        ol_rows,
+        [6.5 * cm, 3 * cm, 3 * cm, 3 * cm],
+    )
+
+    story.append(Spacer(1, 0.5 * cm))
+    story.append(
+        Paragraph(
+            "Deposito Trujillo · Business Data Analyzer · Cartera Aging",
+            styles["CarSmall"],
+        )
+    )
+
+    doc = SimpleDocTemplate(
+        str(path),
+        pagesize=A4,
+        leftMargin=1.4 * cm,
+        rightMargin=1.4 * cm,
+        topMargin=1.2 * cm,
+        bottomMargin=1.2 * cm,
+        title=f"Cartera Aging {as_of}",
+    )
+    doc.build(story)
+    return path

--- a/tests/ai/test_recommended_reports.py
+++ b/tests/ai/test_recommended_reports.py
@@ -80,7 +80,7 @@ class TestRecommendedReportsCatalog:
     def test_payload_includes_period_defaults_and_month_names(self):
         payload = recommended_reports_payload(today=date(2024, 12, 15))
         assert "reports" in payload
-        assert len(payload["reports"]) == 7
+        assert len(payload["reports"]) == 8
         assert payload["default_year"] == 2024
         assert payload["default_month"] == 11
         assert payload["month_names"]["12"] == "Diciembre"
@@ -123,6 +123,7 @@ class TestRecommendedReportsCatalog:
         assert "informe-week" in patched
         assert "generate_kpi_board" in patched
         assert "generate_rotacion" in patched
+        assert "generate_cartera" in patched
         assert "informe-as-of" in patched
 
 
@@ -176,6 +177,10 @@ class TestRecommendedReportsFlaskRoutes:
         assert rot_entry["period_type"] == "as_of_date"
         assert rot_entry["action"]["type"] == "generate_rotacion"
         assert "as_of_date" in rot_entry["action"]
+        car_entry = next(r for r in payload["reports"] if r["id"] == "cartera-aging")
+        assert car_entry["period_type"] == "as_of_date"
+        assert car_entry["action"]["type"] == "generate_cartera"
+        assert "as_of_date" in car_entry["action"]
 
         evidence = tmp_path / "recommended-reports.json"
         evidence.write_text(json.dumps(payload, ensure_ascii=False, indent=2))

--- a/tests/core/test_cartera_aging.py
+++ b/tests/core/test_cartera_aging.py
@@ -1,0 +1,203 @@
+"""Unit tests for cartera / AR aging (no live DB)."""
+
+from business_analyzer.core.cartera_aging import (
+    SNAPSHOT_SELECT_COLUMNS,
+    aggregate_clients,
+    bucket_breakdown,
+    build_dso_sales_sql,
+    build_report_from_rows,
+    build_snapshot_sql,
+    compute_dso,
+    compute_summary,
+    over_limit_clients,
+    top_concentration,
+    top_overdue,
+)
+
+
+def _sample_rows():
+    return [
+        {
+            "cliente_uid": 1,
+            "cliente_nit": "9001",
+            "cliente_razon_social": "Cliente Alfa",
+            "cliente_ciudad": "Cali",
+            "cliente_departamento": "Valle",
+            "vendedor_nombre": "Ana",
+            "corriente": 100_000,
+            "vencido": 50_000,
+            "vencido_30": 50_000,
+            "vencido_60": 0,
+            "vencido_90": 0,
+            "vencido_120": 0,
+            "vencido_360": 0,
+            "vencido_superior": 0,
+            "total": 150_000,
+            "dias_vencidos": 20,
+            "cliente_cupo": 200_000,
+            "fecha_carga": "2026-07-28 19:00:00",
+        },
+        {
+            "cliente_uid": 1,
+            "cliente_nit": "9001",
+            "cliente_razon_social": "Cliente Alfa",
+            "cliente_ciudad": "Cali",
+            "cliente_departamento": "Valle",
+            "vendedor_nombre": "Ana",
+            "corriente": 0,
+            "vencido": 80_000,
+            "vencido_30": 0,
+            "vencido_60": 0,
+            "vencido_90": 80_000,
+            "vencido_120": 0,
+            "vencido_360": 0,
+            "vencido_superior": 0,
+            "total": 80_000,
+            "dias_vencidos": 95,
+            "cliente_cupo": 200_000,
+            "fecha_carga": "2026-07-28 19:00:00",
+        },
+        {
+            "cliente_uid": 2,
+            "cliente_nit": "9002",
+            "cliente_razon_social": "Cliente Beta",
+            "cliente_ciudad": "Bogotá",
+            "cliente_departamento": "Cundinamarca",
+            "vendedor_nombre": "Luis",
+            "corriente": 500_000,
+            "vencido": 0,
+            "vencido_30": 0,
+            "vencido_60": 0,
+            "vencido_90": 0,
+            "vencido_120": 0,
+            "vencido_360": 0,
+            "vencido_superior": 0,
+            "total": 500_000,
+            "dias_vencidos": 0,
+            "cliente_cupo": 300_000,
+            "fecha_carga": "2026-07-28 19:00:00",
+        },
+        {
+            "cliente_uid": 3,
+            "cliente_nit": "9003",
+            "cliente_razon_social": "Cliente Gamma",
+            "cliente_ciudad": "Medellín",
+            "cliente_departamento": "Antioquia",
+            "vendedor_nombre": "Ana",
+            "corriente": 0,
+            "vencido": 1_000_000,
+            "vencido_30": 0,
+            "vencido_60": 0,
+            "vencido_90": 0,
+            "vencido_120": 200_000,
+            "vencido_360": 800_000,
+            "vencido_superior": 0,
+            "total": 1_000_000,
+            "dias_vencidos": 200,
+            "cliente_cupo": 2_000_000,
+            "fecha_carga": "2026-07-28 19:00:00",
+        },
+    ]
+
+
+def test_snapshot_sql_uses_max_fecha_carga_and_limited_columns():
+    sql = build_snapshot_sql().upper()
+    assert "BANCO_CARTERA" in sql
+    assert "MAX(FECHA_CARGA)" in sql
+    for col in SNAPSHOT_SELECT_COLUMNS:
+        assert col.upper() in sql
+    # No document-level noise columns in SELECT
+    assert "DOCUMENTO_NUMERO" not in sql
+    assert "DEBITOS" not in sql
+
+
+def test_snapshot_sql_as_of_filter():
+    sql = build_snapshot_sql(as_of_date="2026-07-28")
+    assert "CAST(fecha_carga AS DATE)" in sql
+    assert "2026-07-28" in sql
+
+
+def test_dso_sales_sql_excludes_test_docs():
+    sql = build_dso_sales_sql(as_of_date="2026-07-28", dso_days=30).upper()
+    assert "BANCO_DATOS" in sql
+    assert "DOCUMENTOSCODIGO NOT IN" in sql
+    for code in ("XY", "AS", "TS"):
+        assert f"'{code}'" in sql
+    assert "TOTALSINIVA" in sql
+
+
+def test_aggregate_clients_sums_and_over_limit():
+    clients = aggregate_clients(_sample_rows())
+    assert len(clients) == 3
+    alfa = next(c for c in clients if c["cliente_uid"] == 1)
+    assert alfa["total"] == 230_000
+    assert alfa["vencido"] == 130_000
+    assert alfa["dias_vencidos"] == 95
+    assert alfa["documentos"] == 2
+    # total 230k > cupo 200k
+    assert alfa["sobre_cupo"] is True
+    beta = next(c for c in clients if c["cliente_uid"] == 2)
+    assert beta["sobre_cupo"] is True  # 500k > 300k cupo
+    gamma = next(c for c in clients if c["cliente_uid"] == 3)
+    assert gamma["sobre_cupo"] is False
+    assert gamma["vencido_90_plus"] == 1_000_000
+
+
+def test_summary_and_buckets_q9_aligned():
+    clients = aggregate_clients(_sample_rows())
+    summary = compute_summary(
+        clients, document_row_count=4, dso_dias=40.0, ventas_netas=1e6
+    )
+    assert summary["Cartera_Total"] == 1_730_000
+    assert summary["Cartera_Vencida"] == 1_130_000
+    assert abs(summary["Cartera_Vencida_Pct"] - (1_130_000 * 100 / 1_730_000)) < 0.01
+    assert summary["Cartera_Vencida_90_Plus"] == 1_080_000  # 80k + 1M
+    assert summary["Clientes_Sobre_Cupo"] == 2
+    assert summary["DSO_Dias"] == 40.0
+    buckets = bucket_breakdown(summary)
+    assert len(buckets) == 7
+    assert sum(b["amount"] for b in buckets) == (
+        summary["Bucket_Corriente"]
+        + summary["Bucket_Vencido_30"]
+        + summary["Bucket_Vencido_60"]
+        + summary["Bucket_Vencido_90"]
+        + summary["Bucket_Vencido_120"]
+        + summary["Bucket_Vencido_360"]
+        + summary["Bucket_Vencido_Superior"]
+    )
+
+
+def test_top_overdue_concentration_over_limit():
+    clients = aggregate_clients(_sample_rows())
+    od = top_overdue(clients, top_n=5)
+    assert od[0]["cliente_razon_social"] == "Cliente Gamma"
+    conc = top_concentration(clients, top_n=10)
+    assert conc[0]["cliente_razon_social"] == "Cliente Gamma"
+    assert conc[0]["share_acum"] > 0.5
+    ol = over_limit_clients(clients)
+    assert len(ol) == 2
+
+
+def test_compute_dso():
+    # cartera 1_000_000, ventas 500_000 over 30 days → DSO = 60
+    assert abs(compute_dso(1_000_000, 500_000, 30) - 60.0) < 0.01
+    assert compute_dso(1_000_000, 0, 30) == 0.0
+
+
+def test_build_report_from_rows_structure():
+    report = build_report_from_rows(
+        _sample_rows(),
+        as_of_date="2026-07-28",
+        top_n=10,
+        dso_days=30,
+        ventas_netas=2_000_000,
+        include_dso=True,
+    )
+    assert report["as_of_date"] == "2026-07-28"
+    assert report["source"] == "banco_cartera"
+    assert "XY" in report["excluded_document_codes"]
+    assert report["summary"]["Cartera_Total"] == 1_730_000
+    assert report["summary"]["DSO_Dias"] is not None
+    assert report["top_overdue"]
+    assert report["buckets"]
+    assert report["client_count"] == 3

--- a/tests/reports/test_cartera_api.py
+++ b/tests/reports/test_cartera_api.py
@@ -1,0 +1,254 @@
+"""Tests for Cartera aging web API helpers and report renderers."""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))
+
+from business_analyzer.ai.flask_app import (
+    SmartVannaFlaskApp,
+    cartera_api_payload,
+    cartera_status_text,
+)
+from business_analyzer.reports.cartera_aging import (
+    build_cartera_result,
+    cartera_output_basename,
+    default_as_of_date,
+    render_markdown,
+    validate_as_of_date,
+)
+from business_analyzer.reports.cartera_html import build_insights, render_html
+
+
+def _fake_report():
+    return {
+        "as_of_date": "2026-07-28",
+        "fecha_carga_snapshot": "2026-07-28 19:00:00",
+        "source": "banco_cartera",
+        "dso_days_window": 30,
+        "include_dso": True,
+        "excluded_document_codes": ["XY", "AS", "TS"],
+        "summary": {
+            "Cartera_Total": 1_730_000,
+            "Cartera_Corriente": 600_000,
+            "Cartera_Vencida": 1_130_000,
+            "Cartera_Vencida_Pct": 65.3,
+            "Cartera_Vencida_90_Plus": 1_080_000,
+            "Cartera_Vencida_90_Plus_Pct": 62.4,
+            "Clientes_Con_Saldo": 3,
+            "Clientes_Sobre_Cupo": 2,
+            "Documentos_Filas": 4,
+            "Dias_Vencidos_Promedio_Ponderado": 120.0,
+            "DSO_Dias": 26.0,
+            "Ventas_Netas_Periodo": 2_000_000,
+            "Dias_Periodo": 30,
+            "Bucket_Corriente": 600_000,
+            "Bucket_Vencido_30": 50_000,
+            "Bucket_Vencido_60": 0,
+            "Bucket_Vencido_90": 80_000,
+            "Bucket_Vencido_120": 200_000,
+            "Bucket_Vencido_360": 800_000,
+            "Bucket_Vencido_Superior": 0,
+        },
+        "buckets": [
+            {
+                "bucket": "corriente",
+                "label": "Corriente (al día)",
+                "amount": 600_000,
+                "share_pct": 34.7,
+            },
+            {
+                "bucket": "vencido_30",
+                "label": "Vencido 1–30 d",
+                "amount": 50_000,
+                "share_pct": 2.9,
+            },
+        ],
+        "top_overdue": [
+            {
+                "cliente_razon_social": "Cliente Gamma",
+                "vendedor_nombre": "Ana",
+                "vencido": 1_000_000,
+                "total": 1_000_000,
+                "dias_vencidos": 200,
+                "vencido_90_plus": 1_000_000,
+            }
+        ],
+        "top_concentration": [
+            {
+                "cliente_razon_social": "Cliente Gamma",
+                "total": 1_000_000,
+                "share_total": 0.58,
+                "share_acum": 0.58,
+                "vencido": 1_000_000,
+            }
+        ],
+        "over_limit": [
+            {
+                "cliente_razon_social": "Cliente Beta",
+                "cliente_cupo": 300_000,
+                "total": 500_000,
+                "exceso_cupo": 200_000,
+                "vendedor_nombre": "Luis",
+            }
+        ],
+        "by_vendedor": [
+            {
+                "vendedor_nombre": "Ana",
+                "clientes": 2,
+                "total": 1_230_000,
+                "vencido": 1_130_000,
+                "vencido_90_plus": 1_080_000,
+            }
+        ],
+        "client_count": 3,
+        "document_row_count": 4,
+    }
+
+
+class _StubVanna:
+    run_sql_is_set = True
+
+
+class TestCarteraHelpers:
+    def test_default_as_of_date_is_yesterday(self):
+        assert default_as_of_date(today=date(2026, 7, 30)) == "2026-07-29"
+
+    def test_validate_as_of_date(self):
+        assert validate_as_of_date("2026-07-28") == "2026-07-28"
+        with pytest.raises(ValueError):
+            validate_as_of_date("28-07-2026")
+
+    def test_basename(self):
+        assert (
+            cartera_output_basename("2026-07-28", "html")
+            == "CARTERA_AGING_2026-07-28.html"
+        )
+        assert (
+            cartera_output_basename("2026-07-28", "pdf")
+            == "CARTERA_AGING_2026-07-28.pdf"
+        )
+
+    def test_render_markdown_includes_sections(self):
+        md = render_markdown(_fake_report())
+        assert "Cartera" in md
+        assert "Buckets" in md or "aging" in md.lower()
+        assert "Top clientes vencidos" in md
+        assert "sobre cupo" in md.lower()
+
+    def test_build_insights_spanish_with_severity(self):
+        insights = build_insights(_fake_report())
+        assert len(insights) >= 4
+        titles = " ".join(i["title"] for i in insights)
+        assert "cartera" in titles.lower() or "Pulso" in titles
+        assert any(
+            i.get("severity") in ("danger", "warning", "info", "success")
+            for i in insights
+        )
+        assert any(
+            "7 días" in i.get("title", "") or "7 días" in i.get("body", "")
+            for i in insights
+        )
+
+    def test_render_html_colombian_currency(self):
+        html = render_html(_fake_report())
+        assert "Cartera" in html
+        assert "$1.730.000" in html or "$1.000.000" in html
+        assert "Insights" in html or "plan de cobranza" in html.lower()
+
+    def test_build_cartera_result_invalid_date(self):
+        result = build_cartera_result(as_of_date="bad")
+        assert result["status"] == "error"
+
+    def test_build_cartera_result_writes_file(self, tmp_path):
+        class FakeRunner:
+            def __init__(self, *a, **k):
+                pass
+
+            def build_report(self, as_of):
+                r = _fake_report()
+                r["as_of_date"] = as_of
+                return r
+
+        with patch(
+            "business_analyzer.reports.cartera_aging.CarteraAgingRunner",
+            FakeRunner,
+        ):
+            result = build_cartera_result(
+                as_of_date="2026-07-28",
+                output_dir=tmp_path,
+                fmt="html",
+            )
+        assert result["status"] == "success"
+        assert result["format"] == "html"
+        path = Path(result["path"])
+        assert path.is_file()
+        assert path.suffix == ".html"
+        html = path.read_text(encoding="utf-8")
+        assert "Cartera" in html
+
+    def test_cartera_api_payload(self):
+        payload = cartera_api_payload(
+            {
+                "status": "success",
+                "message": "ok",
+                "path": "/tmp/CARTERA_AGING_2026-07-28.html",
+                "as_of_date": "2026-07-28",
+            },
+            "cache-1",
+        )
+        assert payload["type"] == "cartera"
+        assert payload["download_url"] == "/reports/CARTERA_AGING_2026-07-28.html"
+        assert "2026-07-28" in cartera_status_text(
+            {"as_of_date": "2026-07-28", "path": payload["download_url"]}
+        )
+
+
+@pytest.fixture
+def cartera_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    app = SmartVannaFlaskApp(_StubVanna(), chart=False)
+    app.flask_app.config["TESTING"] = True
+    with app.flask_app.test_client() as client:
+        yield client, tmp_path
+
+
+class TestCarteraFlaskRoute:
+    def test_generate_cartera_endpoint(self, cartera_client):
+        client, tmp_path = cartera_client
+        html_out = tmp_path / "CARTERA_AGING_2026-07-28.html"
+        html_out.write_text("<html>cartera</html>", encoding="utf-8")
+        with patch(
+            "business_analyzer.reports.cartera_aging.build_cartera_result",
+            return_value={
+                "status": "success",
+                "format": "html",
+                "as_of_date": "2026-07-28",
+                "path": str(html_out),
+                "message": "ok",
+                "insights_count": 5,
+            },
+        ):
+            response = client.post(
+                "/api/v0/generate_cartera",
+                json={"as_of_date": "2026-07-28", "format": "html"},
+            )
+
+        assert response.status_code == 200
+        payload = response.get_json()
+        assert payload["type"] == "cartera"
+        assert payload["as_of_date"] == "2026-07-28"
+        assert payload["download_url"] == "/reports/CARTERA_AGING_2026-07-28.html"
+
+    def test_generate_cartera_requires_date(self, cartera_client):
+        client, _ = cartera_client
+        response = client.post("/api/v0/generate_cartera", json={})
+        assert response.status_code == 200
+        assert response.get_json()["type"] == "error"


### PR DESCRIPTION
## Summary
- Add **Cartera / AR aging** report from SmartBusiness `banco_cartera` (latest snapshot): current vs overdue buckets, top overdue clients, concentration, Spanish managerial insights.
- Aesthetic **HTML** (default) + **PDF** outputs, CLI (`run_cartera_aging.py`), and Vanna **Informes recomendados** card.
- Wire `POST /api/v0/generate_cartera` with download URL (same pattern as Rotación de Existencias).
- Unit tests mock the report dict (no live DB required for CI).

## Test plan
- [x] `pytest tests/core/test_cartera_aging.py tests/reports/test_cartera_api.py tests/ai/test_recommended_reports.py -q`
- [x] Pre-commit (black, isort, flake8, mypy)
- [ ] After merge: pull production, restart `business-analyzer`, hard-refresh 8084
- [ ] Generate Cartera HTML + PDF from Informes recomendados against live `banco_cartera`
- [ ] Spot-check totals vs ERP aging sample if available