### PR TITLE
feat(reports): customer invoice summary in Vanna Informes recomendados

### DIFF
--- a/reports/README.md
+++ b/reports/README.md
@@ -9,6 +9,7 @@ This directory contains generated analysis reports and their supporting data.
 - `DATABASE_TABLE_ANALYSIS_RECOMMENDATIONS.md` - Strategic recommendations companion (2026-07-07 baseline)
 - `ROTACION_EXISTENCIAS_<date>.html` (also `.pdf` / `.md` via CLI) - Commercial warehouse inventory turnover (quiebre, muerto, transfers); CLI or **Vanna UI → Informes recomendados** at `http://127.0.0.1:8084/`
 - `CARTERA_AGING_<date>.html` (also `.pdf` / `.md` / `.json` via CLI) - AR aging from `banco_cartera` (mora, buckets, top vencidos, cupos); CLI `scripts/analysis/run_cartera_aging.py` or **Informes recomendados → Cartera / Aging**
+- `RESUMEN_FACTURAS_<cliente>.html` (also `.pdf`) - Customer invoice summary from pasted invoice numbers; **Informes recomendados → Resumen de facturas**
 - `CRITICAL_INVENTORY_<date>.md` - Risk shortlist (Q13); commercial WH + warehouse demand
 - `ANALYSIS_REPORT.md` - Comprehensive analysis across all categories
 - `KPI_CONTROL_BOARD_TEMPLATE.md` - Weekly KPI operating template (scorecard + actions)

--- a/src/business_analyzer/ai/flask_app.py
+++ b/src/business_analyzer/ai/flask_app.py
@@ -183,6 +183,38 @@ def cartera_api_payload(result: Dict[str, Any], cache_id: str) -> Dict[str, Any]
     }
 
 
+def invoice_summary_status_text(result: Dict[str, Any]) -> str:
+    filename = Path(result["path"]).name if result.get("path") else None
+    customer = result.get("customer_name") or "cliente"
+    count = result.get("invoice_count") or 0
+    if filename:
+        return f"✓ Resumen de facturas listo — {customer} ({count} docs, {filename})"
+    return f"✓ Resumen de facturas — {customer} ({count} docs)"
+
+
+def invoice_summary_api_payload(
+    result: Dict[str, Any], cache_id: str
+) -> Dict[str, Any]:
+    status = result.get("status")
+    if status == "error":
+        return {
+            "type": "error",
+            "id": cache_id,
+            "error": result.get("message", "Error generando resumen de facturas"),
+        }
+    return {
+        "type": "invoice_summary",
+        "id": cache_id,
+        "text": result.get("message", ""),
+        "status_text": invoice_summary_status_text(result),
+        "download_url": manager_report_download_path(result.get("path")),
+        "format": result.get("format", "html"),
+        "invoice_count": result.get("invoice_count"),
+        "customer_name": result.get("customer_name"),
+        "missing": result.get("missing") or [],
+    }
+
+
 def manager_report_api_payload(result: Dict[str, Any], cache_id: str) -> Dict[str, Any]:
     """Serialize a manager report routing result for the Vanna web UI."""
     status = result.get("status")
@@ -573,6 +605,68 @@ class SmartVannaFlaskApp(VannaFlaskApp):
             cache.set(id=cache_id, field="cartera", value=result)
             return jsonify(cartera_api_payload(result, cache_id))
 
+        @requires_auth
+        def generate_invoice_summary(user):
+            invoices = flask.request.args.get("invoices")
+            fmt = flask.request.args.get("format", "html")
+            document_code = flask.request.args.get("document_code")
+
+            if flask.request.method == "POST":
+                body = flask.request.get_json(silent=True) or {}
+                invoices = body.get("invoices", invoices)
+                fmt = body.get("format", fmt)
+                document_code = body.get("document_code", document_code)
+
+            if isinstance(invoices, list):
+                invoices_text = " ".join(str(n) for n in invoices)
+            else:
+                invoices_text = str(invoices or "").strip()
+
+            if not invoices_text:
+                return jsonify(
+                    {
+                        "type": "error",
+                        "error": "Pega al menos un número de factura.",
+                    }
+                )
+
+            fmt = str(fmt or "html").strip().lower()
+            code = str(document_code or "").strip().upper() or None
+            cache_id = cache.generate_id(
+                invoices=invoices_text,
+                format=fmt,
+                document_code=code or "",
+                report="invoice_summary",
+            )
+
+            try:
+                from business_analyzer.reports.invoice_summary import (
+                    build_invoice_summary_result,
+                )
+
+                result = build_invoice_summary_result(
+                    invoices=invoices_text,
+                    document_code=code,
+                    fmt=fmt,
+                )
+            except Exception:
+                logging.getLogger(__name__).exception(
+                    "generate_invoice_summary failed fmt=%s", fmt
+                )
+                result = {
+                    "status": "error",
+                    "message": (
+                        "Error generando el resumen de facturas. "
+                        "Revise los números o los logs del servidor."
+                    ),
+                }
+
+            if result.get("status") == "error":
+                return jsonify(invoice_summary_api_payload(result, cache_id))
+
+            cache.set(id=cache_id, field="invoice_summary", value=result)
+            return jsonify(invoice_summary_api_payload(result, cache_id))
+
         @self.flask_app.route("/api/v0/recommended_reports", methods=["GET"])
         def recommended_reports():
             return jsonify(recommended_reports_payload())
@@ -613,6 +707,12 @@ class SmartVannaFlaskApp(VannaFlaskApp):
             "/api/v0/generate_cartera",
             endpoint="smart_generate_cartera",
             view_func=generate_cartera,
+            methods=["GET", "POST"],
+        )
+        self.flask_app.add_url_rule(
+            "/api/v0/generate_invoice_summary",
+            endpoint="smart_generate_invoice_summary",
+            view_func=generate_invoice_summary,
             methods=["GET", "POST"],
         )
         self._patch_assets_js()

--- a/src/business_analyzer/ai/recommended_reports.py
+++ b/src/business_analyzer/ai/recommended_reports.py
@@ -141,6 +141,16 @@ def get_recommended_report_templates() -> List[Dict[str, Any]]:
             "period_type": "as_of_date",
             "template": {"report_kind": "cartera_aging"},
         },
+        {
+            "id": "resumen-facturas",
+            "title": "Resumen de facturas",
+            "description": (
+                "Resumen comercial para el cliente: pega números de factura. "
+                "Totales, IVA, saldo y detalle de líneas (HTML/PDF)."
+            ),
+            "period_type": "invoices",
+            "template": {"report_kind": "invoice_summary"},
+        },
     ]
 
 
@@ -175,6 +185,17 @@ def get_recommended_reports(*, today: Optional[date] = None) -> List[Dict[str, A
                     "action": {
                         "type": action_type,
                         "as_of_date": as_of,
+                    },
+                }
+            )
+            continue
+        if entry.get("period_type") == "invoices":
+            reports.append(
+                {
+                    **entry,
+                    "action": {
+                        "type": "generate_invoice_summary",
+                        "format": "html",
                     },
                 }
             )
@@ -293,13 +314,22 @@ body.dark #informes-recomendados {
 .informe-month,
 .informe-year,
 .informe-week,
-.informe-format {
+.informe-format,
+.informe-sede,
+.informe-invoices {
   font-size: 0.78rem;
   border: 1px solid #cbd5e1;
   border-radius: 0.4rem;
   padding: 0.3rem 0.45rem;
   background: #f8fafc;
   color: #1e293b;
+}
+.informe-invoices {
+  width: 100%;
+  min-height: 4.2rem;
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  line-height: 1.35;
 }
 .informe-month { flex: 1 1 6.5rem; min-width: 0; }
 .informe-year { width: 4.5rem; }
@@ -308,7 +338,9 @@ body.dark #informes-recomendados {
 .dark .informe-month,
 .dark .informe-year,
 .dark .informe-week,
-.dark .informe-format {
+.dark .informe-format,
+.dark .informe-sede,
+.dark .informe-invoices {
   background: #0f172a;
   border-color: #475569;
   color: #e2e8f0;
@@ -366,7 +398,7 @@ body.informes-layout #app {
 RECOMMENDED_REPORTS_PANEL_HTML = """
 <aside id="informes-recomendados" class="informes-recomendados" aria-label="Informes recomendados">
   <h2>Informes recomendados</h2>
-  <p class="informes-subtitle">Informes mensuales, KPI semanal, rotación o cartera (fecha).</p>
+  <p class="informes-subtitle">Informes mensuales, KPI, rotación, cartera o resumen de facturas.</p>
   <div id="informes-recomendados-list" class="informes-recomendados-list" role="list"></div>
   <p id="informes-recomendados-status" class="informes-recomendados-status" aria-live="polite"></p>
 </aside>
@@ -459,12 +491,27 @@ RECOMMENDED_REPORTS_JS = """
     return response.json();
   }
 
+  async function triggerInvoiceSummary(invoices, fmt, documentCode) {
+    const payload = {
+      invoices: invoices,
+      format: fmt || "html",
+    };
+    if (documentCode) payload.document_code = documentCode;
+    const response = await fetch("/api/v0/generate_invoice_summary", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    return response.json();
+  }
+
   function handleGenerateResult(result) {
     if (
       result.type === "manager_report" ||
       result.type === "kpi_board" ||
       result.type === "rotacion" ||
-      result.type === "cartera"
+      result.type === "cartera" ||
+      result.type === "invoice_summary"
     ) {
       setStatus(shortStatus(result), false);
       if (result.download_url) window.open(result.download_url, "_blank");
@@ -571,6 +618,96 @@ RECOMMENDED_REPORTS_JS = """
     });
   }
 
+  function renderInvoicesCard(report) {
+    const card = document.createElement("div");
+    card.className = "informe-card";
+    card.setAttribute("role", "listitem");
+    card.dataset.reportId = report.id;
+
+    const title = document.createElement("span");
+    title.className = "informe-card-title";
+    title.textContent = report.title;
+
+    const desc = document.createElement("span");
+    desc.className = "informe-card-desc";
+    desc.textContent = report.description;
+
+    const period = document.createElement("div");
+    period.className = "informe-period";
+
+    const invoicesInput = document.createElement("textarea");
+    invoicesInput.className = "informe-invoices";
+    invoicesInput.rows = 4;
+    invoicesInput.placeholder = "447748, 447777, 448060…";
+    invoicesInput.setAttribute("aria-label", "Números de factura");
+
+    const sedeSelect = document.createElement("select");
+    sedeSelect.className = "informe-sede";
+    sedeSelect.setAttribute("aria-label", "Sede de las facturas");
+    [
+      { value: "", label: "Todas las sedes" },
+      { value: "FED", label: "Almacén Principal" },
+      { value: "FEF", label: "Sika Center" },
+      { value: "FET", label: "Calle 5" },
+    ].forEach((opt) => {
+      const option = document.createElement("option");
+      option.value = opt.value;
+      option.textContent = opt.label;
+      sedeSelect.appendChild(option);
+    });
+
+    const formatSelect = document.createElement("select");
+    formatSelect.className = "informe-format";
+    formatSelect.setAttribute("aria-label", "Formato del resumen");
+    [
+      { value: "html", label: "HTML" },
+      { value: "pdf", label: "PDF" },
+    ].forEach((opt) => {
+      const option = document.createElement("option");
+      option.value = opt.value;
+      option.textContent = opt.label;
+      if (opt.value === "html") option.selected = true;
+      formatSelect.appendChild(option);
+    });
+
+    const generateBtn = document.createElement("button");
+    generateBtn.type = "button";
+    generateBtn.className = "informe-generate-btn";
+    generateBtn.textContent = "Generar resumen";
+
+    period.appendChild(invoicesInput);
+    period.appendChild(sedeSelect);
+    period.appendChild(formatSelect);
+    period.appendChild(generateBtn);
+
+    card.appendChild(title);
+    card.appendChild(desc);
+    card.appendChild(period);
+    listEl.appendChild(card);
+
+    generateBtn.addEventListener("click", async () => {
+      const invoices = (invoicesInput.value || "").trim();
+      if (!invoices) {
+        setStatus("Pega al menos un número de factura.", true);
+        return;
+      }
+      const fmt = formatSelect.value || "html";
+      const documentCode = (sedeSelect.value || "").trim();
+      card.classList.add("is-busy");
+      generateBtn.disabled = true;
+      setStatus("Generando resumen de facturas (" + fmt.toUpperCase() + ")…", false);
+      try {
+        const result = await triggerInvoiceSummary(invoices, fmt, documentCode);
+        handleGenerateResult(result);
+      } catch (err) {
+        setStatus("No se pudo contactar el servidor.", true);
+      } finally {
+        card.classList.remove("is-busy");
+        generateBtn.disabled = false;
+      }
+    });
+  }
+
   function renderWeekCard(report, defaults) {
     const card = document.createElement("div");
     card.className = "informe-card";
@@ -647,6 +784,10 @@ RECOMMENDED_REPORTS_JS = """
     }
     if (report.period_type === "as_of_date") {
       renderAsOfDateCard(report, defaults);
+      return;
+    }
+    if (report.period_type === "invoices") {
+      renderInvoicesCard(report);
       return;
     }
     const card = document.createElement("div");

--- a/src/business_analyzer/core/invoice_summary.py
+++ b/src/business_analyzer/core/invoice_summary.py
@@ -1,0 +1,403 @@
+"""Assemble a customer-facing summary from selected invoice numbers."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any, Dict, List, Mapping, Optional, Sequence, cast
+
+from business_analyzer.core.database import Database, qualified_sb_table
+from depotru_kernel.documents import excluded_document_sql_in_list
+
+MAX_INVOICES = 40
+MIN_INVOICE_DIGITS = 5
+
+SEDE_PUBLIC_NAMES: Dict[str, str] = {
+    "FED": "Almacén Principal",
+    "FEF": "Sika Center",
+    "FET": "Calle 5",
+}
+
+_INVOICE_RE = re.compile(r"\d{" + str(MIN_INVOICE_DIGITS) + r",10}")
+
+
+def parse_invoice_numbers(text: str) -> List[int]:
+    """Extract unique invoice numbers from free text (commas, newlines, codes)."""
+    seen: set[int] = set()
+    out: List[int] = []
+    for match in _INVOICE_RE.finditer(text or ""):
+        value = int(match.group(0))
+        if value <= 0 or value in seen:
+            continue
+        seen.add(value)
+        out.append(value)
+        if len(out) >= MAX_INVOICES:
+            break
+    return out
+
+
+def public_sede_name(document_code: Any) -> str:
+    code = str(document_code or "").strip().upper()
+    return SEDE_PUBLIC_NAMES.get(code, "Sede comercial")
+
+
+def _as_float(value: Any) -> float:
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _as_int(value: Any) -> int:
+    if value is None:
+        return 0
+    try:
+        return int(Decimal(str(value)))
+    except (TypeError, ValueError, Exception):
+        return 0
+
+
+def _as_date(value: Any) -> Optional[date]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text[:10])
+    except ValueError:
+        return None
+
+
+def _clean(text: Any) -> str:
+    return re.sub(r"\s+", " ", str(text or "")).strip()
+
+
+def assemble_invoice_summary(
+    *,
+    requested: Sequence[int],
+    line_rows: Sequence[Mapping[str, Any]],
+    cartera_rows: Sequence[Mapping[str, Any]] | None = None,
+) -> Dict[str, Any]:
+    """Build a customer-facing report dict from already-fetched rows."""
+    requested_list = [int(n) for n in requested]
+    cartera_index: Dict[tuple, Mapping[str, Any]] = {}
+    for row in cartera_rows or []:
+        tipo = str(row.get("documento_tipo") or "").strip().upper()
+        numero = _as_int(row.get("documento_numero"))
+        if numero:
+            cartera_index[(tipo, numero)] = row
+            cartera_index.setdefault(("", numero), row)
+
+    grouped: Dict[tuple, List[Mapping[str, Any]]] = defaultdict(list)
+    for row in line_rows:
+        key = (
+            str(row.get("DocumentosCodigo") or "").strip().upper(),
+            _as_int(row.get("NumeroDocumento")),
+        )
+        if key[1]:
+            grouped[key].append(row)
+
+    invoices: List[Dict[str, Any]] = []
+    found_numbers: set[int] = set()
+    for (doc_code, numero), rows in sorted(
+        grouped.items(),
+        key=lambda item: (_as_date(item[1][0].get("Fecha")) or date.min, item[0][1]),
+    ):
+        found_numbers.add(numero)
+        first = rows[0]
+        lines = []
+        total_sin = 0.0
+        total_mas = 0.0
+        qty = 0.0
+        for raw in rows:
+            cantidad = _as_float(raw.get("Cantidad"))
+            sin = _as_float(raw.get("TotalSinIva"))
+            mas = _as_float(raw.get("TotalMasIva"))
+            iva_pct = _as_float(raw.get("Iva"))
+            unit = sin / cantidad if cantidad else 0.0
+            lines.append(
+                {
+                    "codigo": str(raw.get("ArticulosCodigo") or "").strip(),
+                    "nombre": _clean(raw.get("ArticulosNombre")),
+                    "categoria": _clean(raw.get("categoria")) or "OTROS",
+                    "cantidad": cantidad,
+                    "unitario_sin_iva": unit,
+                    "total_sin_iva": sin,
+                    "total_mas_iva": mas,
+                    "iva_pct": iva_pct,
+                    "iva_valor": mas - sin,
+                    "exento": abs(iva_pct) < 0.01,
+                }
+            )
+            total_sin += sin
+            total_mas += mas
+            qty += cantidad
+        car = cartera_index.get((doc_code, numero)) or cartera_index.get(("", numero))
+        vence = _as_date((car or {}).get("documento_fecha_vencimiento"))
+        saldo = _as_float((car or {}).get("total")) if car else total_mas
+        invoices.append(
+            {
+                "codigo": doc_code,
+                "sede": public_sede_name(doc_code),
+                "numero": numero,
+                "fecha": (_as_date(first.get("Fecha")) or date.min).isoformat(),
+                "vence": vence.isoformat() if vence else None,
+                "detalle": _clean(first.get("Detalle")),
+                "dias_credito": _as_int(first.get("DiasCredito")),
+                "vendedor": _clean(first.get("VendedorFactura")),
+                "terceros_id": first.get("TercerosID"),
+                "nit": str(first.get("TercerosIdentificacion") or "").strip(),
+                "cliente": _clean(first.get("TercerosNombres")),
+                "lineas": len(lines),
+                "cantidad": qty,
+                "total_sin_iva": total_sin,
+                "iva": total_mas - total_sin,
+                "total_mas_iva": total_mas,
+                "saldo": saldo,
+                "pagado": bool(
+                    car
+                    and (
+                        car.get("documento_fecha_cancela")
+                        or _as_float(car.get("total")) == 0
+                    )
+                ),
+                "corriente": _as_float((car or {}).get("corriente")),
+                "vencido": _as_float((car or {}).get("vencido")),
+                "lines": lines,
+            }
+        )
+
+    missing = [n for n in requested_list if n not in found_numbers]
+
+    by_customer: Dict[tuple, List[Dict[str, Any]]] = defaultdict(list)
+    for inv in invoices:
+        by_customer[
+            (inv.get("terceros_id"), inv.get("nit"), inv.get("cliente"))
+        ].append(inv)
+
+    customers = []
+    for (tid, nit, name), invs in by_customer.items():
+        customers.append(
+            {
+                "terceros_id": tid,
+                "nit": nit,
+                "name": name,
+                "invoices": [i["numero"] for i in invs],
+                "total_mas_iva": sum(i["total_mas_iva"] for i in invs),
+                "saldo": sum(i["saldo"] for i in invs),
+            }
+        )
+    customers.sort(key=lambda c: -c["total_mas_iva"])
+    multiple = len(customers) > 1
+    primary = customers[0] if customers else {"name": "", "nit": ""}
+
+    obras = sorted({inv["detalle"] for inv in invoices if inv.get("detalle")})
+    obra = obras[0] if len(obras) == 1 else None
+
+    families: Dict[str, float] = defaultdict(float)
+    sku_map: Dict[str, Dict[str, Any]] = {}
+    for inv in invoices:
+        for line in inv["lines"]:
+            families[line["categoria"]] += line["total_mas_iva"]
+            sku = line["codigo"] or line["nombre"]
+            entry = sku_map.setdefault(
+                sku,
+                {
+                    "codigo": line["codigo"],
+                    "nombre": line["nombre"],
+                    "cantidad": 0.0,
+                    "total_sin_iva": 0.0,
+                    "facturas": set(),
+                },
+            )
+            entry["cantidad"] += line["cantidad"]
+            entry["total_sin_iva"] += line["total_sin_iva"]
+            entry["facturas"].add(inv["numero"])
+
+    repeated = []
+    for entry in sku_map.values():
+        facts = sorted(entry["facturas"])
+        if len(facts) < 2:
+            continue
+        repeated.append(
+            {
+                "codigo": entry["codigo"],
+                "nombre": entry["nombre"],
+                "facturas": facts,
+                "cantidad": entry["cantidad"],
+                "total_sin_iva": entry["total_sin_iva"],
+            }
+        )
+    repeated.sort(key=lambda r: -r["total_sin_iva"])
+
+    family_rows = [
+        {"categoria": name, "total_mas_iva": amount}
+        for name, amount in sorted(families.items(), key=lambda kv: -kv[1])
+    ]
+
+    total_sin = sum(i["total_sin_iva"] for i in invoices)
+    total_mas = sum(i["total_mas_iva"] for i in invoices)
+    exento = sum(
+        line["total_sin_iva"]
+        for inv in invoices
+        for line in inv["lines"]
+        if line["exento"]
+    )
+    saldo = sum(i["saldo"] for i in invoices)
+
+    return {
+        "requested": requested_list,
+        "missing": missing,
+        "multiple_customers": multiple,
+        "customer": {"name": primary.get("name", ""), "nit": primary.get("nit", "")},
+        "customers": customers,
+        "obra": obra,
+        "obras": obras,
+        "invoices": invoices,
+        "families": family_rows,
+        "repeated": repeated,
+        "summary": {
+            "invoice_count": len(invoices),
+            "line_count": sum(i["lineas"] for i in invoices),
+            "total_sin_iva": total_sin,
+            "base_gravada": total_sin - exento,
+            "exento": exento,
+            "iva": total_mas - total_sin,
+            "total_mas_iva": total_mas,
+            "saldo": saldo,
+            "pagos": max(total_mas - saldo, 0.0),
+        },
+    }
+
+
+class InvoiceSummaryRunner:
+    """Load selected invoices from SmartBusiness and assemble the summary."""
+
+    def __init__(
+        self,
+        db: Optional[Database] = None,
+        *,
+        sb_database: Optional[str] = None,
+        document_code: Optional[str] = None,
+    ) -> None:
+        self.db = db or Database()
+        self.sb_database = sb_database
+        code = str(document_code or "").strip().upper()
+        self.document_code = code or None
+
+    def _execute(
+        self, sql: str, params: Optional[tuple] = None
+    ) -> List[Dict[str, Any]]:
+        self.db.connect()
+        rows = cast(
+            List[Dict[str, Any]],
+            self.db.execute_query(sql, params),
+        )
+        return [dict(row) for row in rows]
+
+    def fetch_lines(self, numbers: Sequence[int]) -> List[Dict[str, Any]]:
+        if not numbers:
+            return []
+        table = qualified_sb_table("banco_datos", self.sb_database)
+        excluded = excluded_document_sql_in_list()
+        placeholders = ",".join(["%s"] * len(numbers))
+        sql = f"""
+SELECT
+    DocumentosCodigo, DocumentosNombre, NumeroDocumento, Fecha,
+    TercerosID, TercerosIdentificacion, TercerosNombres, DiasCredito,
+    VendedorFactura, ArticulosCodigo, ArticulosNombre, categoria,
+    Cantidad, TotalSinIva, TotalMasIva, Iva
+FROM {table}
+WHERE NumeroDocumento IN ({placeholders})
+  AND DocumentosCodigo NOT IN ({excluded})
+""".strip()
+        params: List[Any] = list(numbers)
+        if self.document_code:
+            sql += " AND DocumentosCodigo = %s"
+            params.append(self.document_code)
+        sql += " ORDER BY Fecha, NumeroDocumento, ArticulosNombre"
+        return self._execute(sql, tuple(params))
+
+    def fetch_headers(self, numbers: Sequence[int]) -> List[Dict[str, Any]]:
+        """Invoice-level Detalle from v_banco_facturas when available."""
+        if not numbers:
+            return []
+        table = qualified_sb_table("v_banco_facturas", self.sb_database)
+        excluded = excluded_document_sql_in_list()
+        placeholders = ",".join(["%s"] * len(numbers))
+        sql = f"""
+SELECT DocumentosCodigo, NumeroDocumento, Detalle, DiasCredito
+FROM {table}
+WHERE NumeroDocumento IN ({placeholders})
+  AND DocumentosCodigo NOT IN ({excluded})
+""".strip()
+        params: List[Any] = list(numbers)
+        if self.document_code:
+            sql += " AND DocumentosCodigo = %s"
+            params.append(self.document_code)
+        try:
+            return self._execute(sql, tuple(params))
+        except Exception:
+            return []
+
+    def fetch_cartera(self, numbers: Sequence[int]) -> List[Dict[str, Any]]:
+        if not numbers:
+            return []
+        table = qualified_sb_table("banco_cartera", self.sb_database)
+        placeholders = ",".join(["%s"] * len(numbers))
+        sql = f"""
+SELECT
+    documento_tipo, documento_numero, documento_fecha_vencimiento,
+    documento_fecha_cancela, debitos, creditos, total, corriente,
+    vencido, dias_vencidos
+FROM {table}
+WHERE documento_numero IN ({placeholders})
+""".strip()
+        params: List[Any] = list(numbers)
+        if self.document_code:
+            sql += " AND LTRIM(RTRIM(documento_tipo)) = %s"
+            params.append(self.document_code)
+        try:
+            return self._execute(sql, tuple(params))
+        except Exception:
+            return []
+
+    def build_report(self, numbers: Sequence[int]) -> Dict[str, Any]:
+        lines = self.fetch_lines(numbers)
+        headers = {
+            (
+                _clean(h.get("DocumentosCodigo")).upper(),
+                _as_int(h.get("NumeroDocumento")),
+            ): h
+            for h in self.fetch_headers(numbers)
+        }
+        if headers:
+            enriched = []
+            for row in lines:
+                key = (
+                    str(row.get("DocumentosCodigo") or "").strip().upper(),
+                    _as_int(row.get("NumeroDocumento")),
+                )
+                extra = headers.get(key) or {}
+                merged = dict(row)
+                if extra.get("Detalle") and not merged.get("Detalle"):
+                    merged["Detalle"] = extra.get("Detalle")
+                if extra.get("DiasCredito") is not None:
+                    merged["DiasCredito"] = extra.get("DiasCredito")
+                enriched.append(merged)
+            lines = enriched
+        cartera = self.fetch_cartera(numbers)
+        return assemble_invoice_summary(
+            requested=numbers,
+            line_rows=lines,
+            cartera_rows=cartera,
+        )

--- a/src/business_analyzer/reports/invoice_summary.py
+++ b/src/business_analyzer/reports/invoice_summary.py
@@ -1,0 +1,304 @@
+"""Customer invoice summary report for CLI and Vanna web UI."""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Sequence
+
+from business_analyzer.ai.base import Config
+from business_analyzer.core.database import Database
+from business_analyzer.core.invoice_summary import (
+    InvoiceSummaryRunner,
+    parse_invoice_numbers,
+)
+
+MONTHS_SHORT = {
+    1: "ene",
+    2: "feb",
+    3: "mar",
+    4: "abr",
+    5: "may",
+    6: "jun",
+    7: "jul",
+    8: "ago",
+    9: "sep",
+    10: "oct",
+    11: "nov",
+    12: "dic",
+}
+
+
+def cop(value: Any, *, cents: bool = True) -> str:
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    if cents:
+        text = f"{num:,.2f}"
+        return "$" + text.replace(",", "X").replace(".", ",").replace("X", ".")
+    return f"${num:,.0f}".replace(",", ".")
+
+
+def qty(value: Any) -> str:
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    if abs(num - round(num)) < 1e-9:
+        return f"{int(round(num)):,}".replace(",", ".")
+    text = f"{num:.2f}"
+    return text.replace(".", ",")
+
+
+def fmt_date(value: Any) -> str:
+    if not value:
+        return "—"
+    if isinstance(value, date):
+        d = value
+    else:
+        try:
+            d = date.fromisoformat(str(value)[:10])
+        except ValueError:
+            return str(value)
+    return f"{d.day} {MONTHS_SHORT[d.month]} {d.year}"
+
+
+def slugify(text: str) -> str:
+    normalized = unicodedata.normalize("NFKD", text or "")
+    ascii_text = normalized.encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", ascii_text).strip("_").lower()
+    return slug[:40]
+
+
+def invoice_summary_output_basename(fmt: str = "html", slug: str = "") -> str:
+    ext = {
+        "html": "html",
+        "pdf": "pdf",
+        "markdown": "md",
+        "md": "md",
+        "json": "json",
+    }.get((fmt or "html").lower(), "html")
+    if slug:
+        return f"RESUMEN_FACTURAS_{slug}.{ext}"
+    return f"RESUMEN_FACTURAS.{ext}"
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    customer = report.get("customer") or {}
+    invoices = list(report.get("invoices") or [])
+    title_name = customer.get("name") or "Cliente"
+    obra = report.get("obra")
+    lines = [
+        f"# Resumen de facturas — {title_name}",
+        "",
+        f"**Cliente:** {title_name}",
+        f"**Identificación:** {customer.get('nit') or '—'}",
+    ]
+    if obra:
+        lines.append(f"**Obra:** {obra}")
+    if invoices:
+        lines.append(f"**Asesor:** {invoices[0].get('vendedor') or '—'}")
+        lines.append(f"**Sede:** {invoices[0].get('sede') or 'Sede comercial'}")
+    lines.extend(
+        [
+            "",
+            "Este documento es un **resumen comercial**. "
+            "No reemplaza las facturas DIAN.",
+            "",
+            "## Totales",
+            "",
+            "| Concepto | Valor |",
+            "|---|---|",
+            f"| Subtotal (antes de IVA) | "
+            f"**{cop(summary.get('total_sin_iva'), cents=False)}** |",
+            f"| Base gravada (19%) | {cop(summary.get('base_gravada'), cents=False)} |",
+            f"| Exento de IVA | {cop(summary.get('exento'), cents=False)} |",
+            f"| IVA | **{cop(summary.get('iva'))}** |",
+            f"| **Total facturado** | **{cop(summary.get('total_mas_iva'))}** |",
+            f"| Pagos aplicados | {cop(summary.get('pagos'), cents=False)} |",
+            f"| **Saldo en cartera** | **{cop(summary.get('saldo'), cents=False)}** |",
+            "",
+            "## Facturas",
+            "",
+            "| Factura | Fecha | Vence | Subtotal | IVA | Total | Saldo |",
+            "|---|---|---|---:|---:|---:|---:|",
+        ]
+    )
+    for inv in invoices:
+        lines.append(
+            f"| {inv.get('numero')} | {fmt_date(inv.get('fecha'))} | "
+            f"{fmt_date(inv.get('vence'))} | "
+            f"{cop(inv.get('total_sin_iva'), cents=False)} | "
+            f"{cop(inv.get('iva'))} | {cop(inv.get('total_mas_iva'))} | "
+            f"{cop(inv.get('saldo'), cents=False)} |"
+        )
+    lines.append(
+        f"| **Total** | | | **{cop(summary.get('total_sin_iva'), cents=False)}** | "
+        f"**{cop(summary.get('iva'))}** | **{cop(summary.get('total_mas_iva'))}** | "
+        f"**{cop(summary.get('saldo'), cents=False)}** |"
+    )
+
+    if report.get("families"):
+        lines.extend(
+            ["", "## Composición", "", "| Familia | Total con IVA |", "|---|---:|"]
+        )
+        for fam in report["families"]:
+            lines.append(
+                f"| {fam.get('categoria')} | {cop(fam.get('total_mas_iva'))} |"
+            )
+
+    lines.extend(["", "## Detalle por factura", ""])
+    for inv in invoices:
+        lines.append(
+            f"### Factura {inv.get('numero')} — {fmt_date(inv.get('fecha'))} — "
+            f"{cop(inv.get('total_mas_iva'))}"
+        )
+        lines.append("")
+        lines.append("| Artículo | Cant. | Vlr. unit. | Total |")
+        lines.append("|---|---:|---:|---:|")
+        for item in inv.get("lines") or []:
+            name = item.get("nombre") or ""
+            if item.get("exento"):
+                name += " (exento IVA)"
+            lines.append(
+                f"| {name} | {qty(item.get('cantidad'))} | "
+                f"{cop(item.get('unitario_sin_iva'), cents=False)} | "
+                f"{cop(item.get('total_mas_iva'))} |"
+            )
+        lines.append("")
+
+    if report.get("repeated"):
+        lines.extend(
+            [
+                "## Artículos que se repiten entre facturas",
+                "",
+                "| Artículo | Facturas | Cant. | Subtotal |",
+                "|---|---|---:|---:|",
+            ]
+        )
+        for item in report["repeated"]:
+            facts = " + ".join(str(n) for n in item.get("facturas") or [])
+            lines.append(
+                f"| {item.get('nombre')} | {facts} | {qty(item.get('cantidad'))} | "
+                f"{cop(item.get('total_sin_iva'), cents=False)} |"
+            )
+        lines.append("")
+
+    missing = report.get("missing") or []
+    if missing:
+        listed = ", ".join(str(n) for n in missing)
+        lines.extend(
+            [
+                "## Facturas no encontradas",
+                "",
+                f"No aparecen en ventas: {listed}.",
+                "",
+            ]
+        )
+    if report.get("multiple_customers"):
+        lines.extend(
+            [
+                "## Varios clientes",
+                "",
+                "Las facturas pertenecen a más de un cliente. El total consolidado "
+                "mezcla cuentas distintas.",
+                "",
+            ]
+        )
+    lines.append(f"*Depósito Trujillo · Elaborado el {fmt_date(date.today())}*")
+    return "\n".join(lines)
+
+
+def build_invoice_summary_result(
+    *,
+    invoices: str | Sequence[int] = "",
+    document_code: Optional[str] = None,
+    output_dir: Optional[Path] = None,
+    fmt: str = "html",
+    db: Optional[Database] = None,
+    report: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    if isinstance(invoices, str):
+        numbers = parse_invoice_numbers(invoices)
+    else:
+        numbers = [int(n) for n in invoices]
+    if not numbers:
+        return {
+            "status": "error",
+            "message": "Indica al menos un número de factura.",
+        }
+
+    fmt_norm = (fmt or "html").strip().lower()
+    if fmt_norm in ("md", "markdown"):
+        fmt_norm = "markdown"
+    if fmt_norm not in ("html", "pdf", "markdown", "json"):
+        return {
+            "status": "error",
+            "message": f"Formato inválido: {fmt!r} (use html, pdf, markdown o json)",
+        }
+
+    if report is None:
+        try:
+            runner = InvoiceSummaryRunner(db, document_code=document_code)
+            report = runner.build_report(numbers)
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "status": "error",
+                "message": f"Error consultando facturas: {exc}",
+            }
+
+    if not report.get("invoices"):
+        missing = ", ".join(str(n) for n in report.get("missing") or numbers)
+        return {
+            "status": "error",
+            "message": f"No se encontraron las facturas: {missing}.",
+        }
+
+    slug = slugify(str((report.get("customer") or {}).get("name") or "cliente"))
+    out_dir = Path(output_dir) if output_dir else Config.ensure_output_dir()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / invoice_summary_output_basename(fmt_norm, slug=slug)
+
+    try:
+        if fmt_norm == "html":
+            from business_analyzer.reports.invoice_summary_html import render_html
+
+            path.write_text(render_html(report), encoding="utf-8")
+        elif fmt_norm == "pdf":
+            from business_analyzer.reports.invoice_summary_pdf import (
+                write_invoice_summary_pdf,
+            )
+
+            write_invoice_summary_pdf(report, path)
+        elif fmt_norm == "json":
+            path.write_text(json.dumps(report, indent=2, default=str), encoding="utf-8")
+        else:
+            path.write_text(render_markdown(report), encoding="utf-8")
+    except Exception as exc:  # noqa: BLE001
+        return {
+            "status": "error",
+            "message": f"Error escribiendo informe ({fmt_norm}): {exc}",
+        }
+
+    summary = report.get("summary") or {}
+    customer = report.get("customer") or {}
+    return {
+        "status": "success",
+        "format": fmt_norm if fmt_norm != "markdown" else "markdown",
+        "path": str(path.resolve()),
+        "invoice_count": summary.get("invoice_count"),
+        "customer_name": customer.get("name"),
+        "summary": summary,
+        "missing": list(report.get("missing") or []),
+        "message": (
+            f"Resumen de facturas — {customer.get('name') or 'cliente'} "
+            f"({summary.get('invoice_count')} docs, "
+            f"{cop(summary.get('total_mas_iva'))})\n"
+            f"Archivo: {path.name}"
+        ),
+    }

--- a/src/business_analyzer/reports/invoice_summary_html.py
+++ b/src/business_analyzer/reports/invoice_summary_html.py
@@ -1,0 +1,265 @@
+"""Self-contained HTML for the customer invoice summary."""
+
+from __future__ import annotations
+
+from datetime import date
+from html import escape
+from typing import Any, Mapping
+
+from business_analyzer.reports.invoice_summary import cop, fmt_date, qty
+
+
+def render_html(report: Mapping[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    customer = report.get("customer") or {}
+    invoices = list(report.get("invoices") or [])
+    name = escape(str(customer.get("name") or "Cliente"))
+    nit = escape(str(customer.get("nit") or "—"))
+    obra = escape(str(report.get("obra") or ""))
+    sede = escape(
+        str((invoices[0].get("sede") if invoices else "") or "Sede comercial")
+    )
+    vendedor = escape(str((invoices[0].get("vendedor") if invoices else "") or "—"))
+    generated = fmt_date(date.today())
+
+    inv_rows = []
+    for inv in invoices:
+        inv_rows.append(
+            "<tr>"
+            f"<td>{escape(str(inv.get('numero')))}</td>"
+            f"<td>{escape(fmt_date(inv.get('fecha')))}</td>"
+            f"<td>{escape(fmt_date(inv.get('vence')))}</td>"
+            f"<td class='num'>{cop(inv.get('total_sin_iva'), cents=False)}</td>"
+            f"<td class='num'>{cop(inv.get('iva'))}</td>"
+            f"<td class='num'>{cop(inv.get('total_mas_iva'))}</td>"
+            f"<td class='num'>{cop(inv.get('saldo'), cents=False)}</td>"
+            "</tr>"
+        )
+    inv_rows.append(
+        "<tr class='total'>"
+        "<td colspan='3'><strong>Total</strong></td>"
+        f"<td class='num'><strong>"
+        f"{cop(summary.get('total_sin_iva'), cents=False)}</strong></td>"
+        f"<td class='num'><strong>{cop(summary.get('iva'))}</strong></td>"
+        f"<td class='num'><strong>{cop(summary.get('total_mas_iva'))}</strong></td>"
+        f"<td class='num'><strong>"
+        f"{cop(summary.get('saldo'), cents=False)}</strong></td>"
+        "</tr>"
+    )
+
+    fam_rows = "".join(
+        f"<tr><td>{escape(str(f.get('categoria')))}</td>"
+        f"<td class='num'>{cop(f.get('total_mas_iva'))}</td></tr>"
+        for f in (report.get("families") or [])
+    )
+
+    detail = []
+    for inv in invoices:
+        rows = []
+        for item in inv.get("lines") or []:
+            label = str(item.get("nombre") or "")
+            if item.get("exento"):
+                label += " (exento IVA)"
+            rows.append(
+                "<tr>"
+                f"<td>{escape(label)}</td>"
+                f"<td class='num'>{qty(item.get('cantidad'))}</td>"
+                f"<td class='num'>{cop(item.get('unitario_sin_iva'), cents=False)}</td>"
+                f"<td class='num'>{cop(item.get('total_mas_iva'))}</td>"
+                "</tr>"
+            )
+        detail.append(
+            f"<h3>Factura {escape(str(inv.get('numero')))} · "
+            f"{escape(fmt_date(inv.get('fecha')))} · "
+            f"{cop(inv.get('total_mas_iva'))}</h3>"
+            "<table><thead><tr><th>Artículo</th><th>Cant.</th>"
+            "<th>Vlr. unit.</th><th>Total</th></tr></thead>"
+            f"<tbody>{''.join(rows)}</tbody></table>"
+        )
+
+    repeated_html = ""
+    if report.get("repeated"):
+        rrows = []
+        for item in report["repeated"]:
+            facts = " + ".join(str(n) for n in item.get("facturas") or [])
+            rrows.append(
+                "<tr>"
+                f"<td>{escape(str(item.get('nombre')))}</td>"
+                f"<td>{escape(facts)}</td>"
+                f"<td class='num'>{qty(item.get('cantidad'))}</td>"
+                f"<td class='num'>{cop(item.get('total_sin_iva'), cents=False)}</td>"
+                "</tr>"
+            )
+        repeated_html = (
+            "<section><h2>Artículos que se repiten</h2>"
+            "<table><thead><tr><th>Artículo</th><th>Facturas</th>"
+            "<th>Cant.</th><th>Subtotal</th></tr></thead>"
+            f"<tbody>{''.join(rrows)}</tbody></table></section>"
+        )
+
+    alerts = []
+    if report.get("missing"):
+        listed = ", ".join(str(n) for n in report["missing"])
+        alerts.append(f"<div class='callout'>No encontradas: {escape(listed)}.</div>")
+    if report.get("multiple_customers"):
+        alerts.append(
+            "<div class='callout'>Las facturas pertenecen a más de un cliente.</div>"
+        )
+
+    obra_chip = f'<span class="chip">{obra}</span>' if obra else ""
+
+    return f"""<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Resumen de facturas — {name}</title>
+  <style>
+    :root {{
+      --brick: #7A3A22;
+      --ink: #1A1410;
+      --muted: #5C534C;
+      --bg: #F7F3EE;
+      --card: #ffffff;
+      --rule: #D4C8BC;
+    }}
+    * {{ box-sizing: border-box; margin: 0; padding: 0; }}
+    body {{
+      font-family: "Segoe UI", system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--ink);
+      line-height: 1.5;
+    }}
+    .wrap {{ max-width: 1080px; margin: 0 auto; padding: 1.5rem 1.2rem 3rem; }}
+    header {{
+      background: var(--brick);
+      color: #fff;
+      border-radius: 1rem;
+      padding: 1.6rem 1.5rem;
+      margin-bottom: 1.25rem;
+    }}
+    header p.kicker {{
+      font-size: 0.75rem; letter-spacing: 0.08em;
+      text-transform: uppercase; opacity: 0.85;
+    }}
+    header h1 {{ font-size: 1.7rem; margin: 0.25rem 0 0.4rem; }}
+    header .sub {{ opacity: 0.92; font-size: 0.95rem; }}
+    .chips {{ margin-top: 0.8rem; display: flex; flex-wrap: wrap; gap: 0.4rem; }}
+    .chip {{
+      background: rgba(255,255,255,0.14);
+      border: 1px solid rgba(255,255,255,0.28);
+      padding: 0.25rem 0.65rem;
+      border-radius: 999px;
+      font-size: 0.78rem;
+    }}
+    .kpis {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 0.7rem;
+      margin-bottom: 1.1rem;
+    }}
+    .kpi {{
+      background: var(--card);
+      border: 1px solid var(--rule);
+      border-radius: 0.8rem;
+      padding: 0.85rem;
+    }}
+    .kpi .label {{
+      font-size: 0.7rem; text-transform: uppercase;
+      color: var(--muted); letter-spacing: 0.04em;
+    }}
+    .kpi .value {{ font-size: 1.15rem; font-weight: 700; margin-top: 0.2rem; }}
+    section {{
+      background: var(--card);
+      border: 1px solid var(--rule);
+      border-radius: 0.9rem;
+      padding: 1.1rem 1.2rem;
+      margin-bottom: 1rem;
+    }}
+    h2 {{ font-size: 1.1rem; margin-bottom: 0.7rem; color: var(--brick); }}
+    h3 {{ font-size: 0.95rem; margin: 1rem 0 0.4rem; }}
+    table {{ width: 100%; border-collapse: collapse; font-size: 0.85rem; }}
+    th {{
+      background: var(--brick);
+      color: #fff;
+      text-align: left;
+      padding: 0.4rem 0.5rem;
+      font-weight: 600;
+    }}
+    td {{
+      padding: 0.38rem 0.5rem;
+      border-bottom: 1px solid var(--rule);
+      vertical-align: top;
+    }}
+    tr:nth-child(even) td {{ background: #F7F3EE; }}
+    tr.total td {{ background: #EFE6DC; border-top: 2px solid var(--brick); }}
+    .num {{ text-align: right; white-space: nowrap; }}
+    .callout {{
+      border-left: 4px solid var(--brick);
+      background: #EFE6DC;
+      padding: 0.7rem 0.9rem;
+      margin-bottom: 0.8rem;
+      border-radius: 0 0.5rem 0.5rem 0;
+    }}
+    footer {{ font-size: 0.78rem; color: var(--muted); margin-top: 1.2rem; }}
+    @media print {{
+      body {{ background: #fff; }}
+      header {{ break-inside: avoid; }}
+    }}
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <p class="kicker">Resumen comercial de facturas</p>
+      <h1>{name}</h1>
+      <p class="sub">CC/NIT {nit} · {sede} · Asesor {vendedor}</p>
+      <div class="chips">
+        <span class="chip">{summary.get('invoice_count') or 0} facturas</span>
+        {obra_chip}
+        <span class="chip">Saldo {cop(summary.get('saldo'), cents=False)}</span>
+      </div>
+    </header>
+    {''.join(alerts)}
+    <div class="kpis">
+      <div class="kpi">
+        <div class="label">Subtotal</div>
+        <div class="value">{cop(summary.get('total_sin_iva'), cents=False)}</div>
+      </div>
+      <div class="kpi">
+        <div class="label">IVA</div>
+        <div class="value">{cop(summary.get('iva'))}</div>
+      </div>
+      <div class="kpi">
+        <div class="label">Total</div>
+        <div class="value">{cop(summary.get('total_mas_iva'))}</div>
+      </div>
+      <div class="kpi">
+        <div class="label">Saldo</div>
+        <div class="value">{cop(summary.get('saldo'), cents=False)}</div>
+      </div>
+    </div>
+    <section>
+      <h2>Facturas</h2>
+      <table>
+        <thead><tr><th>Factura</th><th>Fecha</th><th>Vence</th><th>Subtotal</th><th>IVA</th><th>Total</th><th>Saldo</th></tr></thead>
+        <tbody>{''.join(inv_rows)}</tbody>
+      </table>
+    </section>
+    <section>
+      <h2>Composición</h2>
+      <table>
+        <thead><tr><th>Familia</th><th>Total con IVA</th></tr></thead>
+        <tbody>{fam_rows}</tbody>
+      </table>
+    </section>
+    <section>
+      <h2>Detalle por factura</h2>
+      {''.join(detail)}
+    </section>
+    {repeated_html}
+    <footer>Depósito Trujillo · {generated} · No reemplaza las facturas DIAN.</footer>
+  </div>
+</body>
+</html>
+"""

--- a/src/business_analyzer/reports/invoice_summary_pdf.py
+++ b/src/business_analyzer/reports/invoice_summary_pdf.py
@@ -1,0 +1,439 @@
+"""PDF export for the customer invoice summary (ReportLab)."""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Any, List, Mapping, Sequence
+
+from business_analyzer.reports.invoice_summary import cop, fmt_date, qty
+
+try:
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+    from reportlab.lib.units import cm
+    from reportlab.platypus import (
+        HRFlowable,
+        KeepTogether,
+        Paragraph,
+        SimpleDocTemplate,
+        Spacer,
+        Table,
+        TableStyle,
+    )
+
+    REPORTLAB_AVAILABLE = True
+except ImportError:
+    REPORTLAB_AVAILABLE = False
+
+BRICK = colors.HexColor("#7A3A22")
+INK = colors.HexColor("#1A1410")
+MUTED = colors.HexColor("#5C534C")
+RULE = colors.HexColor("#D4C8BC")
+ROW = colors.HexColor("#F7F3EE")
+PAGE_W, PAGE_H = A4
+MARGIN_X = 1.8 * cm
+
+
+def write_invoice_summary_pdf(report: Mapping[str, Any], path: Path) -> Path:
+    if not REPORTLAB_AVAILABLE:
+        raise RuntimeError(
+            "ReportLab no está instalado. Instálelo con: pip install reportlab"
+        )
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    base = getSampleStyleSheet()
+    styles = {
+        "kicker": ParagraphStyle(
+            "kicker",
+            parent=base["Normal"],
+            fontName="Helvetica",
+            fontSize=8,
+            textColor=BRICK,
+            spaceAfter=2,
+        ),
+        "title": ParagraphStyle(
+            "title",
+            parent=base["Normal"],
+            fontName="Times-Bold",
+            fontSize=18,
+            leading=22,
+            textColor=INK,
+            spaceAfter=4,
+        ),
+        "sub": ParagraphStyle(
+            "sub",
+            parent=base["Normal"],
+            fontName="Helvetica",
+            fontSize=9.5,
+            leading=13,
+            textColor=MUTED,
+            spaceAfter=8,
+        ),
+        "h1": ParagraphStyle(
+            "h1s",
+            parent=base["Normal"],
+            fontName="Times-Bold",
+            fontSize=12.5,
+            leading=16,
+            textColor=INK,
+            spaceBefore=12,
+            spaceAfter=5,
+        ),
+        "h2": ParagraphStyle(
+            "h2s",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=9.5,
+            leading=12,
+            textColor=INK,
+            spaceBefore=8,
+            spaceAfter=3,
+        ),
+        "body": ParagraphStyle(
+            "body",
+            parent=base["Normal"],
+            fontName="Helvetica",
+            fontSize=8.5,
+            leading=12,
+            textColor=INK,
+            spaceAfter=5,
+        ),
+        "th": ParagraphStyle(
+            "th",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=7.5,
+            leading=10,
+            textColor=colors.white,
+        ),
+        "thr": ParagraphStyle(
+            "thr",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=7.5,
+            leading=10,
+            textColor=colors.white,
+            alignment=2,
+        ),
+        "td": ParagraphStyle(
+            "td",
+            parent=base["Normal"],
+            fontName="Helvetica",
+            fontSize=7.5,
+            leading=10,
+            textColor=INK,
+        ),
+        "tdr": ParagraphStyle(
+            "tdr",
+            parent=base["Normal"],
+            fontName="Helvetica",
+            fontSize=7.5,
+            leading=10,
+            textColor=INK,
+            alignment=2,
+        ),
+        "tdb": ParagraphStyle(
+            "tdb",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=7.5,
+            leading=10,
+            textColor=INK,
+        ),
+        "tdbr": ParagraphStyle(
+            "tdbr",
+            parent=base["Normal"],
+            fontName="Helvetica-Bold",
+            fontSize=7.5,
+            leading=10,
+            textColor=INK,
+            alignment=2,
+        ),
+        "callout": ParagraphStyle(
+            "callout",
+            parent=base["Normal"],
+            fontName="Helvetica",
+            fontSize=8.5,
+            leading=12,
+            textColor=INK,
+        ),
+        "meta": ParagraphStyle(
+            "meta",
+            parent=base["Normal"],
+            fontName="Helvetica",
+            fontSize=8,
+            leading=11,
+            textColor=MUTED,
+        ),
+    }
+
+    content_w = PAGE_W - 2 * MARGIN_X
+
+    def P(text: Any, style: str = "td") -> Paragraph:
+        return Paragraph(str(text), styles[style])
+
+    def table(
+        headers: Sequence[str],
+        rows: Sequence[Sequence[Any]],
+        col_widths: Sequence[float],
+        right_cols: set[int] | None = None,
+        last_bold: bool = False,
+    ) -> Table:
+        right = set(right_cols or [])
+        data = [[P(h, "thr" if i in right else "th") for i, h in enumerate(headers)]]
+        for r_i, row in enumerate(rows):
+            is_last = last_bold and r_i == len(rows) - 1
+            cells = []
+            for i, cell in enumerate(row):
+                if is_last:
+                    st = "tdbr" if i in right else "tdb"
+                else:
+                    st = "tdr" if i in right else "td"
+                cells.append(P(cell, st))
+            data.append(cells)
+        grid = Table(data, colWidths=list(col_widths), repeatRows=1)
+        cmds: List[Any] = [
+            ("BACKGROUND", (0, 0), (-1, 0), BRICK),
+            ("VALIGN", (0, 0), (-1, -1), "TOP"),
+            ("LEFTPADDING", (0, 0), (-1, -1), 4),
+            ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+            ("TOPPADDING", (0, 0), (-1, -1), 3),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+            ("BOX", (0, 0), (-1, -1), 0.4, RULE),
+            ("LINEBELOW", (0, 1), (-1, -2), 0.2, RULE),
+        ]
+        for i in range(1, len(data)):
+            if i % 2 == 0:
+                cmds.append(("BACKGROUND", (0, i), (-1, i), ROW))
+        if last_bold:
+            cmds.append(("BACKGROUND", (0, -1), (-1, -1), colors.HexColor("#EFE6DC")))
+            cmds.append(("LINEABOVE", (0, -1), (-1, -1), 0.6, BRICK))
+        grid.setStyle(TableStyle(cmds))
+        return grid
+
+    def callout(text: str) -> Table:
+        inner = Table([[P(text, "callout")]], colWidths=[content_w - 8])
+        inner.setStyle(
+            TableStyle(
+                [
+                    ("LEFTPADDING", (0, 0), (-1, -1), 10),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 10),
+                    ("TOPPADDING", (0, 0), (-1, -1), 7),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 7),
+                    ("BACKGROUND", (0, 0), (-1, -1), ROW),
+                    ("LINEBEFORE", (0, 0), (0, -1), 3, BRICK),
+                ]
+            )
+        )
+        return inner
+
+    def header_footer(canvas, doc):
+        canvas.saveState()
+        canvas.setFillColor(BRICK)
+        canvas.rect(0, PAGE_H - 6, PAGE_W, 6, fill=1, stroke=0)
+        canvas.setStrokeColor(RULE)
+        canvas.setLineWidth(0.6)
+        canvas.line(MARGIN_X, 1.4 * cm, PAGE_W - MARGIN_X, 1.4 * cm)
+        canvas.setFillColor(MUTED)
+        canvas.setFont("Helvetica", 7.5)
+        name = str((report.get("customer") or {}).get("name") or "Cliente")
+        canvas.drawString(MARGIN_X, 1.0 * cm, f"Depósito Trujillo  ·  {name[:48]}")
+        canvas.drawRightString(PAGE_W - MARGIN_X, 1.0 * cm, str(doc.page))
+        canvas.restoreState()
+
+    summary = report.get("summary") or {}
+    customer = report.get("customer") or {}
+    invoices = list(report.get("invoices") or [])
+    story: list = []
+    story.append(P("RESUMEN COMERCIAL DE FACTURAS", "kicker"))
+    story.append(P(str(customer.get("name") or "Cliente"), "title"))
+    sub = f"Identificación {customer.get('nit') or '—'}"
+    if report.get("obra"):
+        sub += f"  ·  {report.get('obra')}"
+    if invoices:
+        sub += f"  ·  {invoices[0].get('sede') or ''}"
+    story.append(P(sub, "sub"))
+    story.append(HRFlowable(width="100%", thickness=1.2, color=BRICK, spaceAfter=8))
+    story.append(
+        P(
+            "Resumen de facturas electrónicas de venta. "
+            "No reemplaza las facturas DIAN.",
+            "body",
+        )
+    )
+    story.append(
+        callout(
+            f"<b>Saldo pendiente: {cop(summary.get('saldo'), cents=False)}.</b>  "
+            f"Subtotal {cop(summary.get('total_sin_iva'), cents=False)} + "
+            f"IVA {cop(summary.get('iva'))} = total "
+            f"{cop(summary.get('total_mas_iva'))}."
+        )
+    )
+    if report.get("missing"):
+        listed = ", ".join(str(n) for n in report["missing"])
+        story.append(callout(f"No encontradas: {listed}."))
+    if report.get("multiple_customers"):
+        story.append(callout("Las facturas pertenecen a más de un cliente."))
+
+    story.append(P("Totales", "h1"))
+    story.append(
+        table(
+            ["Concepto", "Valor"],
+            [
+                [
+                    "Subtotal (antes de IVA)",
+                    cop(summary.get("total_sin_iva"), cents=False),
+                ],
+                ["Base gravada", cop(summary.get("base_gravada"), cents=False)],
+                ["Exento de IVA", cop(summary.get("exento"), cents=False)],
+                ["IVA", cop(summary.get("iva"))],
+                ["Total facturado", cop(summary.get("total_mas_iva"))],
+                ["Pagos aplicados", cop(summary.get("pagos"), cents=False)],
+                ["Saldo en cartera", cop(summary.get("saldo"), cents=False)],
+            ],
+            [content_w * 0.62, content_w * 0.38],
+            right_cols={1},
+            last_bold=True,
+        )
+    )
+
+    story.append(P("Facturas", "h1"))
+    inv_rows = [
+        [
+            str(inv.get("numero")),
+            fmt_date(inv.get("fecha")),
+            fmt_date(inv.get("vence")),
+            cop(inv.get("total_sin_iva"), cents=False),
+            cop(inv.get("iva")),
+            cop(inv.get("total_mas_iva")),
+        ]
+        for inv in invoices
+    ]
+    inv_rows.append(
+        [
+            "Total",
+            "",
+            "",
+            cop(summary.get("total_sin_iva"), cents=False),
+            cop(summary.get("iva")),
+            cop(summary.get("total_mas_iva")),
+        ]
+    )
+    story.append(
+        table(
+            ["Factura", "Fecha", "Vence", "Subtotal", "IVA", "Total"],
+            inv_rows,
+            [
+                content_w * 0.14,
+                content_w * 0.16,
+                content_w * 0.16,
+                content_w * 0.18,
+                content_w * 0.18,
+                content_w * 0.18,
+            ],
+            right_cols={3, 4, 5},
+            last_bold=True,
+        )
+    )
+
+    if report.get("families"):
+        story.append(P("Composición", "h1"))
+        story.append(
+            table(
+                ["Familia", "Total con IVA"],
+                [
+                    [f.get("categoria"), cop(f.get("total_mas_iva"))]
+                    for f in report["families"]
+                ],
+                [content_w * 0.62, content_w * 0.38],
+                right_cols={1},
+            )
+        )
+
+    story.append(P("Detalle por factura", "h1"))
+    for inv in invoices:
+        line_rows = []
+        for item in inv.get("lines") or []:
+            label = str(item.get("nombre") or "")
+            if item.get("exento"):
+                label += " (exento IVA)"
+            line_rows.append(
+                [
+                    label,
+                    qty(item.get("cantidad")),
+                    cop(item.get("unitario_sin_iva"), cents=False),
+                    cop(item.get("total_mas_iva")),
+                ]
+            )
+        story.append(
+            KeepTogether(
+                [
+                    P(
+                        f"Factura {inv.get('numero')}  ·  "
+                        f"{fmt_date(inv.get('fecha'))}  ·  "
+                        f"{cop(inv.get('total_mas_iva'))}",
+                        "h2",
+                    ),
+                    table(
+                        ["Artículo", "Cant.", "Vlr. unit.", "Total"],
+                        line_rows,
+                        [
+                            content_w * 0.50,
+                            content_w * 0.12,
+                            content_w * 0.18,
+                            content_w * 0.20,
+                        ],
+                        right_cols={1, 2, 3},
+                    ),
+                    Spacer(1, 4),
+                ]
+            )
+        )
+
+    if report.get("repeated"):
+        story.append(P("Artículos que se repiten", "h1"))
+        story.append(
+            table(
+                ["Artículo", "Facturas", "Cant.", "Subtotal"],
+                [
+                    [
+                        r.get("nombre"),
+                        " + ".join(str(n) for n in r.get("facturas") or []),
+                        qty(r.get("cantidad")),
+                        cop(r.get("total_sin_iva"), cents=False),
+                    ]
+                    for r in report["repeated"]
+                ],
+                [
+                    content_w * 0.40,
+                    content_w * 0.28,
+                    content_w * 0.12,
+                    content_w * 0.20,
+                ],
+                right_cols={2, 3},
+            )
+        )
+
+    story.append(Spacer(1, 12))
+    story.append(
+        P(
+            f"Depósito Trujillo · Elaborado el {fmt_date(date.today())}",
+            "meta",
+        )
+    )
+
+    doc = SimpleDocTemplate(
+        str(path),
+        pagesize=A4,
+        leftMargin=MARGIN_X,
+        rightMargin=MARGIN_X,
+        topMargin=1.6 * cm,
+        bottomMargin=1.8 * cm,
+        title=f"Resumen de facturas — {customer.get('name') or 'Cliente'}",
+        author="Depósito Trujillo",
+    )
+    doc.build(story, onFirstPage=header_footer, onLaterPages=header_footer)
+    return path

--- a/tests/ai/test_recommended_reports.py
+++ b/tests/ai/test_recommended_reports.py
@@ -80,7 +80,7 @@ class TestRecommendedReportsCatalog:
     def test_payload_includes_period_defaults_and_month_names(self):
         payload = recommended_reports_payload(today=date(2024, 12, 15))
         assert "reports" in payload
-        assert len(payload["reports"]) == 8
+        assert len(payload["reports"]) == 9
         assert payload["default_year"] == 2024
         assert payload["default_month"] == 11
         assert payload["month_names"]["12"] == "Diciembre"
@@ -124,7 +124,9 @@ class TestRecommendedReportsCatalog:
         assert "generate_kpi_board" in patched
         assert "generate_rotacion" in patched
         assert "generate_cartera" in patched
+        assert "generate_invoice_summary" in patched
         assert "informe-as-of" in patched
+        assert "informe-invoices" in patched
 
 
 @pytest.fixture
@@ -181,6 +183,9 @@ class TestRecommendedReportsFlaskRoutes:
         assert car_entry["period_type"] == "as_of_date"
         assert car_entry["action"]["type"] == "generate_cartera"
         assert "as_of_date" in car_entry["action"]
+        inv_entry = next(r for r in payload["reports"] if r["id"] == "resumen-facturas")
+        assert inv_entry["period_type"] == "invoices"
+        assert inv_entry["action"]["type"] == "generate_invoice_summary"
 
         evidence = tmp_path / "recommended-reports.json"
         evidence.write_text(json.dumps(payload, ensure_ascii=False, indent=2))

--- a/tests/reports/test_invoice_summary.py
+++ b/tests/reports/test_invoice_summary.py
@@ -1,0 +1,300 @@
+"""Invoice-number customer summary: parser, assembler, renderers."""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))
+
+from business_analyzer.core.invoice_summary import (
+    MAX_INVOICES,
+    assemble_invoice_summary,
+    parse_invoice_numbers,
+    public_sede_name,
+)
+from business_analyzer.reports.invoice_summary import (
+    build_invoice_summary_result,
+    invoice_summary_output_basename,
+    render_markdown,
+)
+
+
+def test_parse_invoice_numbers_from_mixed_text():
+    text = "447748\n447777, 448060 448129; 449437 449438"
+    assert parse_invoice_numbers(text) == [
+        447748,
+        447777,
+        448060,
+        448129,
+        449437,
+        449438,
+    ]
+
+
+def test_parse_invoice_numbers_dedupes_and_drops_junk():
+    assert parse_invoice_numbers("abc 12 447748 447748 FED-447777") == [
+        447748,
+        447777,
+    ]
+
+
+def test_parse_invoice_numbers_empty():
+    assert parse_invoice_numbers("  , ; \n") == []
+
+
+def test_parse_invoice_numbers_caps_list():
+    blob = " ".join(str(100000 + i) for i in range(MAX_INVOICES + 20))
+    parsed = parse_invoice_numbers(blob)
+    assert len(parsed) == MAX_INVOICES
+
+
+def test_public_sede_name_does_not_expose_erp_code():
+    assert public_sede_name("FED") == "Almacén Principal"
+    assert "FED" not in public_sede_name("FED")
+
+
+def _line(
+    numero,
+    *,
+    fecha="2026-08-05",
+    cliente="FREDI TRUJILLO CULMA",
+    nit="12124183",
+    codigo="0020390074",
+    nombre="CODO SANITARIO 45 CC 4 T/PESADO",
+    categoria="TUBERIA Y ACCE PVC",
+    cantidad=4,
+    sin=31200,
+    mas=37128,
+    iva=19,
+    detalle=" CLUB CAMPESTRE LOTE 76",
+    credito=30,
+    vendedor="LUIS ESTEBAN MEDINA",
+    doc="FED",
+    terceros_id=7710,
+):
+    return {
+        "DocumentosCodigo": doc,
+        "DocumentosNombre": "FACTURA ELECTRONICA DE VENTA",
+        "NumeroDocumento": Decimal(str(numero)),
+        "Fecha": date.fromisoformat(fecha),
+        "TercerosID": terceros_id,
+        "TercerosIdentificacion": nit,
+        "TercerosNombres": cliente,
+        "DiasCredito": Decimal(str(credito)),
+        "VendedorFactura": vendedor,
+        "ArticulosCodigo": codigo,
+        "ArticulosNombre": nombre,
+        "categoria": categoria,
+        "Cantidad": Decimal(str(cantidad)),
+        "TotalSinIva": Decimal(str(sin)),
+        "TotalMasIva": Decimal(str(mas)),
+        "Iva": Decimal(str(iva)),
+        "Detalle": detalle,
+    }
+
+
+def test_assemble_groups_invoices_and_totals():
+    lines = [
+        _line(447748, cantidad=4, sin=31200, mas=37128),
+        _line(
+            447748,
+            codigo="0030050010",
+            nombre="LADRILLO TOLETE",
+            categoria="ART Y HERRAM AGRICOLAS",
+            cantidad=600,
+            sin=900000,
+            mas=900000,
+            iva=0,
+        ),
+        _line(
+            447777,
+            codigo="0020090002",
+            nombre="CEMENTO GRIS CEMEX 50KG",
+            categoria="CEMENTO GRIS",
+            cantidad=70,
+            sin=1952930,
+            mas=2323986.70,
+        ),
+    ]
+    cartera = [
+        {
+            "documento_tipo": "FED ",
+            "documento_numero": 447748,
+            "documento_fecha_vencimiento": date(2026, 9, 4),
+            "documento_fecha_cancela": None,
+            "debitos": Decimal("937128"),
+            "creditos": Decimal("0"),
+            "total": Decimal("937128"),
+            "corriente": Decimal("937128"),
+            "vencido": Decimal("0"),
+            "dias_vencidos": -17,
+        }
+    ]
+    report = assemble_invoice_summary(
+        requested=[447748, 447777, 440136],
+        line_rows=lines,
+        cartera_rows=cartera,
+    )
+    assert report["missing"] == [440136]
+    assert report["customer"]["name"] == "FREDI TRUJILLO CULMA"
+    assert report["customer"]["nit"] == "12124183"
+    assert report["summary"]["invoice_count"] == 2
+    assert abs(report["summary"]["total_sin_iva"] - 2884130) < 0.01
+    assert abs(report["summary"]["total_mas_iva"] - 3261114.70) < 0.01
+    assert report["invoices"][0]["numero"] == 447748
+    assert report["invoices"][0]["vence"] == "2026-09-04"
+    assert report["obra"] == "CLUB CAMPESTRE LOTE 76"
+    skus = {item["codigo"] for inv in report["invoices"] for item in inv["lines"]}
+    assert "0030050010" in skus
+
+
+def test_assemble_mixed_customers_sets_multiple_flag():
+    lines = [
+        _line(447748),
+        _line(
+            440136,
+            fecha="2026-07-09",
+            cliente="OTRO CLIENTE SAS",
+            nit="901078509",
+            terceros_id=99,
+            codigo="0020030020",
+            nombre="MALLA",
+            cantidad=1,
+            sin=148492,
+            mas=176705.48,
+            detalle="",
+            credito=0,
+        ),
+    ]
+    report = assemble_invoice_summary(
+        requested=[447748, 440136],
+        line_rows=lines,
+        cartera_rows=[],
+    )
+    assert report["multiple_customers"] is True
+    assert len(report["customers"]) == 2
+
+
+def test_render_markdown_is_spanish_and_omits_costs():
+    report = assemble_invoice_summary(
+        requested=[447748],
+        line_rows=[_line(447748)],
+        cartera_rows=[],
+    )
+    md = render_markdown(report)
+    assert "Fredi" in md or "FREDI" in md
+    assert "447748" in md
+    assert "Costo" not in md
+    assert "FED" not in md
+    assert "$37.128" in md or "$37.128,00" in md
+
+
+def test_basename():
+    assert invoice_summary_output_basename("html") == "RESUMEN_FACTURAS.html"
+    assert invoice_summary_output_basename("pdf", slug="fredi") == (
+        "RESUMEN_FACTURAS_fredi.pdf"
+    )
+
+
+def test_build_result_requires_invoices():
+    result = build_invoice_summary_result(invoices="")
+    assert result["status"] == "error"
+    assert "factura" in result["message"].lower()
+
+
+def test_build_writes_html_without_erp_code(tmp_path):
+    report = assemble_invoice_summary(
+        requested=[447748],
+        line_rows=[_line(447748)],
+        cartera_rows=[],
+    )
+    result = build_invoice_summary_result(
+        invoices=[447748],
+        report=report,
+        output_dir=tmp_path,
+        fmt="html",
+    )
+    assert result["status"] == "success"
+    html = Path(result["path"]).read_text(encoding="utf-8")
+    assert "447748" in html
+    assert "FED" not in html
+    assert "FREDI" in html
+
+
+def test_flask_generate_invoice_summary(tmp_path, monkeypatch):
+    from unittest.mock import patch
+
+    from business_analyzer.ai.flask_app import SmartVannaFlaskApp
+
+    class _Stub:
+        run_sql_is_set = True
+
+        def generate_sql(self, question, allow_llm_to_see_data=True, **kwargs):
+            return None
+
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    html_out = tmp_path / "RESUMEN_FACTURAS_fredi.html"
+    html_out.write_text("<html>ok</html>", encoding="utf-8")
+    app = SmartVannaFlaskApp(_Stub(), chart=False)
+    app.flask_app.config["TESTING"] = True
+    with app.flask_app.test_client() as client:
+        with patch(
+            "business_analyzer.reports.invoice_summary.build_invoice_summary_result",
+            return_value={
+                "status": "success",
+                "format": "html",
+                "path": str(html_out),
+                "message": "ok",
+                "invoice_count": 6,
+                "customer_name": "FREDI TRUJILLO CULMA",
+                "missing": [],
+            },
+        ):
+            response = client.post(
+                "/api/v0/generate_invoice_summary",
+                json={"invoices": "447748 447777", "format": "html"},
+            )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["type"] == "invoice_summary"
+    assert payload["download_url"] == "/reports/RESUMEN_FACTURAS_fredi.html"
+    assert payload["invoice_count"] == 6
+
+
+def test_flask_generate_invoice_summary_requires_numbers(tmp_path, monkeypatch):
+    from business_analyzer.ai.flask_app import SmartVannaFlaskApp
+
+    class _Stub:
+        run_sql_is_set = True
+
+        def generate_sql(self, question, allow_llm_to_see_data=True, **kwargs):
+            return None
+
+    monkeypatch.setenv("OUTPUT_DIR", str(tmp_path))
+    app = SmartVannaFlaskApp(_Stub(), chart=False)
+    app.flask_app.config["TESTING"] = True
+    with app.flask_app.test_client() as client:
+        response = client.post("/api/v0/generate_invoice_summary", json={})
+    assert response.status_code == 200
+    assert response.get_json()["type"] == "error"
+
+
+def test_build_writes_pdf(tmp_path):
+    report = assemble_invoice_summary(
+        requested=[447748],
+        line_rows=[_line(447748)],
+        cartera_rows=[],
+    )
+    result = build_invoice_summary_result(
+        invoices=[447748],
+        report=report,
+        output_dir=tmp_path,
+        fmt="pdf",
+    )
+    assert result["status"] == "success"
+    assert Path(result["path"]).is_file()
+    assert Path(result["path"]).stat().st_size > 500


### PR DESCRIPTION
## Summary
- Adds **Resumen de facturas** to Vanna Informes recomendados: paste invoice numbers, optional sede, HTML or PDF.
- Customer-facing statement with totals, IVA, cartera saldo, and line items. Does not expose ERP codes (FED/FEF/FET) or cost/margin.
- New `/api/v0/generate_invoice_summary` plus unit/API tests.

## Test Plan
- [x] `pytest tests/reports/test_invoice_summary.py tests/ai/test_recommended_reports.py`
- [x] Live generate of six FED invoices for Fredi Trujillo Culma
- [x] Hard-refresh Vanna UI after restart; card appears and generates